### PR TITLE
SI: Yates' Corrections

### DIFF
--- a/R/ChiSquareTest.R
+++ b/R/ChiSquareTest.R
@@ -5,8 +5,6 @@ ChiSquareTest <- function(tableData, correction = FALSE) {
   # print(tableData)
   
   results <- chisq.test(x = tableData, correct = correction)
-
-  # Matrix without Yates correction
   observed <- t(t(as.vector(results$observed)))
   expected <- round(t(t(as.vector(results$expected))), 4)
   ominusE <- round(observed - expected, 4)
@@ -14,24 +12,17 @@ ChiSquareTest <- function(tableData, correction = FALSE) {
   ominusE2byE <- round(ominusE2/expected, 4)
   residuals <- round(t(t(as.vector(results$residuals))), 4)
   
-  resultMatrix <- cbind(observed, expected, ominusE, ominusE2, ominusE2byE, residuals)
-  colnames(resultMatrix) <- c("O", "E", "(O - E)", "(O - E)<sup>2</sup>", "(O - E)<sup>2</sup> / E", "Standardized Residuals")
+  # Yates'-corrected values
+  ominusE2Yates <- round((abs(ominusE) - 0.5)^2, 4)
+  ominusE2byEYates <- round(((abs(ominusE) - 0.5)^2) / expected, 4)
   
-  # Matrix with Yates correction
-  if (correction){
-    oMinusE2Yates <- round((abs(ominusE) - 0.5)^2, 4)
-    oMinusE2byEYates <- round(oMinusE2Yates / expected, 4)
-    
-    resultMatrix <- cbind(observed, expected, ominusE, oMinusE2Yates, oMinusE2byEYates, ominusE2, ominusE2byE, residuals)
-    colnames(resultMatrix) <- c("O", "E", "(O - E)", "(|O - E| - 0.5)<sup>2</sup>", "(|O - E| - 0.5)<sup>2</sup> / E", "(O - E)<sup>2</sup>", "(O - E)<sup>2</sup> / E", "Standardized Residuals")
-  }
-  
+  # always produce matrix with both yates' and non-yates' columns
+  resultMatrix <- cbind(observed, expected, ominusE, ominusE2, ominusE2byE, ominusE2Yates, ominusE2byEYates, residuals)
   resultMatrix <- rbind(resultMatrix, Total = round(colSums(resultMatrix), 4))
+  colnames(resultMatrix) <- c("O", "E", "(O - E)", "(O - E)<sup>2</sup>", "(O - E)<sup>2</sup> / E", "(|O - E| - 0.5)<sup>2</sup>", "(|O - E| - 0.5)<sup>2</sup> / E", "Standardized Residuals")
+  
   fullResults <- list(results, resultMatrix)
   names(fullResults) <- c("Results", "Matrix")
   
   return(fullResults)
 }
-
-
-

--- a/R/statInfr.R
+++ b/R/statInfr.R
@@ -3803,7 +3803,7 @@ statInfrServer <- function(id) {
     
     PrintChiSqTest <- function() {
       data <- chiSqResults()
-      if (input$chiSquareYates){
+      if (input$chiSquareYates && input$chisquareDimension == '2 x 2'){
         chiSqStat <- data$Matrix[nrow(data$Matrix), "(|O - E| - 0.5)<sup>2</sup> / E"]
       } else
         chiSqStat <- data$Matrix[nrow(data$Matrix), "(O - E)<sup>2</sup> / E"]
@@ -3871,7 +3871,7 @@ statInfrServer <- function(id) {
         chiSqSmplf <- paste0(chiSqSmplf, data[row,"(O - E)<sup>2</sup> / E"]," + ")
       }
       
-      chiSqSum <- paste0(chiSqSum, "\\dfrac{(", data[nrow(data) - 1,"O"], " - ", data[nrow(data) - 1,"E"], ")^2}{", data[ncol(data) - 1,"E"], "}")
+      chiSqSum <- paste0(chiSqSum, "\\dfrac{(", data[nrow(data) - 1,"O"], " - ", data[nrow(data) - 1,"E"], ")^2}{", data[nrow(data) - 1,"E"], "}")
       chiSqSmplf <- paste0(chiSqSmplf, data[nrow(data) - 1,"(O - E)<sup>2</sup> / E"])
       
       formula <- tagList(
@@ -7965,80 +7965,28 @@ statInfrServer <- function(id) {
       
       chiSqTest <- suppressWarnings(ChiSquareTest(chiSqActiveMatrix(), input$chiSquareYates))
       
-      # choose columns based on whether Yates' correction applied or not
       yates_applied <- input$chiSquareYates
-      selected_columns <- if (yates_applied) {
-        c("O", "E", "(O - E)", "(|O - E| - 0.5)<sup>2</sup>", "(|O - E| - 0.5)<sup>2</sup> / E", "Standardized Residuals")
+      dimension <- input$chisquareDimension
+      if (yates_applied && dimension == '2 x 2'){
+        selected_cols <- c("O", "E", "(O - E)", "(|O - E| - 0.5)<sup>2</sup>", "(|O - E| - 0.5)<sup>2</sup> / E", "Standardized Residuals")
       } else {
-        c("O", "E", "(O - E)", "(O - E)<sup>2</sup>", "(O - E)<sup>2</sup> / E", "Standardized Residuals")
+        selected_cols <- c("O", "E", "(O - E)", "(O - E)<sup>2</sup>", "(O - E)<sup>2</sup> / E", "Standardized Residuals")
       }
       
-      selected_data <- chiSqTest$Matrix[, selected_columns, drop = FALSE]
+      display_matrix <- chiSqTest$Matrix[, selected_cols, drop = FALSE]
       
-      headers = htmltools::withTags(table(
+      headers <- htmltools::withTags(table(
         class = 'display',
         thead(
-          tr(
-            th("O",
+          tr(lapply(selected_cols, function(colname) {
+            th(HTML(colname),
                class = 'dt-center',
-               style = "border: 1px solid rgba(0, 0, 0, 0.15);
-                      border-bottom: 1px solid  rgba(0, 0, 0, 0.3);"),
-            th("E",
-               class = 'dt-center',
-               style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);'),
-            th("(O - E)",
-               class = 'dt-center',
-               style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);'),
-            list(
-              if (yates_applied) {
-                list(
-                  th(HTML(paste("(|O - E| - 0.5)", sup(2))),
-                     class = 'dt-center',
-                     style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);'),
-                  th(HTML(paste("(|O - E| - 0.5)", sup(2), " / E")),
-                     class = 'dt-center',
-                     style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);')
-                )
-              } else {
-                list(
-                  th(HTML(paste("(O - E)", sup(2))),
-                     class = 'dt-center',
-                     style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);'),
-                  th(HTML(paste("(O - E)", sup(2), "/ E")),
-                     class = 'dt-center',
-                     style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);')
-                )
-              }
-            ),
-            th("Standardized Residuals",
-               class = 'dt-center',
-               style = 'border-right: 1px solid rgba(0, 0, 0, 0.15);
-                      border-top: 1px solid rgba(0, 0, 0, 0.15);')
-            
-          )
+               style = 'border-right: 1px solid rgba(0, 0, 0, 0.15); border-top: 1px solid rgba(0, 0, 0, 0.15);')
+          }))
         )
       ))
       
-      if (yates_applied){
-        column_defs <- list(
-          list(width = '130px', targets = c(0, 1, 2, 5)),  # standard columns
-          list(width = '200px', targets = c(3, 4)),  # wider for Yates correction columns
-          list(className = 'dt-center', targets = c(0, 1, 2, 3, 4, 5))
-        )
-      } else {
-        column_defs <- list(
-          list(width = '130px', targets = c(0, 1, 2, 3, 4, 5)),
-          list(className = 'dt-center', targets = c(0, 1, 2, 3, 4, 5))
-        )
-      }
-      
-      datatable(selected_data,
+      datatable(display_matrix,
                 class = 'cell-border stripe',
                 container = headers,
                 options = list(
@@ -8049,15 +7997,17 @@ statInfrServer <- function(id) {
                   paging = FALSE,
                   autoWidth = FALSE,
                   scrollX = TRUE,
-                  columnDefs = column_defs
+                  columnDefs = list(
+                    list(width = '130px', targets = c(0, 1, 2, 3, 4, 5)),
+                    list(className = 'dt-center', targets = c(0, 1, 2, 3, 4, 5)))
                 ),
                 selection = "none",
                 escape = FALSE,
                 filter = "none",
                 rownames = FALSE) %>%
-        formatStyle(columns = 0:ncol(chiSqTest$Matrix),
+        formatStyle(columns = 0:ncol(display_matrix),
                     target = 'row',
-                    fontWeight = styleRow(dim(chiSqTest$Matrix)[1], "bold"))
+                    fontWeight = styleRow(dim(display_matrix)[1], "bold"))
     })
     
     


### PR DESCRIPTION
Updated table/test statistic/p-value to reflect Yates' corrections for 2x2 dimensions. Note that toggling between different dimensions when Yates' correction is selected may trigger a popup error due to reactivity timing issues. 