### PR TITLE
Logistic Regression and Simple Linear Regression Changes

### DIFF
--- a/R/logisticRegression.R
+++ b/R/logisticRegression.R
@@ -237,7 +237,8 @@ LogisticRegressionServer <- function(id) {
         
         final_table <- summary_coeffs %>%
           mutate(
-            Wald = (Estimate / `Std. Error`)^2 ,
+            `Wald 𝑍` = Estimate / `Std. Error`,
+            `Wald 𝜒²` = (Estimate / `Std. Error`)^2,
             df = 1
           ) %>%
           rownames_to_column("Term") %>%
@@ -246,9 +247,10 @@ LogisticRegressionServer <- function(id) {
             Term,
             Coefficient = Estimate,
             SE = `Std. Error`,
-            Wald,
+            `Wald 𝑍`,
+            `Wald 𝜒²`,
             df,
-            `p-value` = `Pr(>|z|)`,
+            `P-value` = `Pr(>|z|)`,
             OR,
             `Lower 95% CI for OR` = Lower_CI_OR,
             `Upper 95% CI for OR` = Upper_CI_OR


### PR DESCRIPTION
Logistic Regression:
Wald Z was added which is just the sqr root of the current Wald column, Wald x^2 was added which is the current wald column, p-value was renamed to P-value for consistency.

Simple Linear Regression:
Inference tab was added which just contains the coefficients table from the Model tab, Coefficients table was deleted from the Model tab, Kendall Tau formula was added in the correlations analysis tab (I further decomposed the formula for clarity and wanted to check with you if thats okay), The model tab was cleaned up from white spaces in between interpretation and the actual interpretation.