### PR TITLE
Add a Machine Learning tab

### DIFF
--- a/R/machineLearning.R
+++ b/R/machineLearning.R
@@ -1,0 +1,81 @@
+# R/machineLearning.R
+
+machineLearningUI <- function(id) {
+  ns <- NS(id)
+  sidebarLayout(
+    sidebarPanel(
+      shinyjs::useShinyjs(),
+      radioButtons(ns("method"),
+                   tags$b("Methodology"),
+                   choices = list(
+                     "Principal Component Analysis" = "PCA",
+                     "k-Nearest Neighbors"          = "KNN",
+                     "Linear Discriminant Analysis" = "LDA",
+                     "Decision Trees (CART)"        = "CART"
+                   ),
+                   selected = "PCA"
+      ),
+      uiOutput(ns("mlSidebarUI"))
+    ),
+    mainPanel(
+      uiOutput(ns("mlMainPanelUI"))
+    )
+  )
+}
+
+machineLearningServer <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    
+    # Dynamic ID counters for each method
+    pca_instance_counter  <- reactiveVal(0)
+    knn_instance_counter  <- reactiveVal(0)
+    lda_instance_counter  <- reactiveVal(0)
+    cart_instance_counter <- reactiveVal(0)
+    
+    current_pca_module_id  <- reactive({ paste0("ml_pca_",  pca_instance_counter()) })
+    current_knn_module_id  <- reactive({ paste0("ml_knn_",  knn_instance_counter()) })
+    current_lda_module_id  <- reactive({ paste0("ml_lda_",  lda_instance_counter()) })
+    current_cart_module_id <- reactive({ paste0("ml_cart_", cart_instance_counter()) })
+    
+    observeEvent(input$method, {
+      if (input$method == "PCA") {
+        pca_instance_counter(pca_instance_counter() + 1)
+        output$mlSidebarUI  <- renderUI({ PCASidebarUI(session$ns(current_pca_module_id())) })
+        output$mlMainPanelUI <- renderUI({ PCAMainPanelUI(session$ns(current_pca_module_id())) })
+      } else if (input$method == "KNN") {
+        knn_instance_counter(knn_instance_counter() + 1)
+        output$mlSidebarUI  <- renderUI({ KNNSidebarUI(session$ns(current_knn_module_id())) })
+        output$mlMainPanelUI <- renderUI({ KNNMainPanelUI(session$ns(current_knn_module_id())) })
+      } else if (input$method == "LDA") {
+        lda_instance_counter(lda_instance_counter() + 1)
+        output$mlSidebarUI  <- renderUI({ LDASidebarUI(session$ns(current_lda_module_id())) })
+        output$mlMainPanelUI <- renderUI({ LDAMainPanelUI(session$ns(current_lda_module_id())) })
+      } else if (input$method == "CART") {
+        cart_instance_counter(cart_instance_counter() + 1)
+        output$mlSidebarUI  <- renderUI({ CARTSidebarUI(session$ns(current_cart_module_id())) })
+        output$mlMainPanelUI <- renderUI({ CARTMainPanelUI(session$ns(current_cart_module_id())) })
+      }
+    }, ignoreNULL = FALSE, ignoreInit = FALSE)
+    
+    observeEvent(current_pca_module_id(), 
+                 { req(input$method == "PCA");  
+                   PCAServer(current_pca_module_id()) }, 
+                 ignoreNULL = TRUE)
+    
+    observeEvent(current_knn_module_id(), 
+                 { req(input$method == "KNN"); 
+                   KNNServer(current_knn_module_id()) }, 
+                 ignoreNULL = TRUE)
+    
+    observeEvent(current_lda_module_id(), 
+                 { req(input$method == "LDA"); 
+                   LDAServer(current_lda_module_id()) }, 
+                 ignoreNULL = TRUE)
+    
+    observeEvent(current_cart_module_id(),
+                 { req(input$method == "CART"); 
+                   CARTServer(current_cart_module_id()) }, 
+                 ignoreNULL = TRUE)
+    
+  })
+}

--- a/R/regressionAndCorrelation.R
+++ b/R/regressionAndCorrelation.R
@@ -9,11 +9,7 @@ regressionAndCorrelationUI <- function(id) {
                    tags$b("Methodology"),
                    choices = list("Simple Linear Regression and Correlation Analysis" = "SLR",
                                   "Multiple Linear Regression" = "MLR",
-                                  "Binary Logistic Regression" = "LOGR",
-                                  "Principal Component Analysis" = "PCA",
-                                  "k-Nearest Neighbors" = "KNN",
-                                  "Linear Discriminant Analysis" = "LDA",
-                                  "Decision Trees (CART)" = "CART"
+                                  "Binary Logistic Regression" = "LOGR"
                                   ),
                    selected = "SLR"
       ),
@@ -44,29 +40,8 @@ regressionAndCorrelationServer <- function(id) {
       paste0("logr_dynamic_instance_", logr_instance_counter())
     })
     
-    # # --- Dynamic ID Generation for PCA ---
-    pca_instance_counter <- reactiveVal(0)
-    current_pca_module_id <- reactive({
-    paste0("pca_dynamic_instance_", pca_instance_counter())
-    })
-    
-    #Dynamic ID generation for KNN
-    knn_instance_counter <- reactiveVal(0)
-    current_knn_module_id <- reactive({
-      paste0("knn_dynamic_instance_", knn_instance_counter())
-    })
-    
-    #Dynamic ID for LDA
-    lda_instance_counter <- reactiveVal(0)
-    current_lda_module_id <- reactive({
-      paste0("lda_dynamic_instance_", lda_instance_counter())
-    })
   
-    #Dynamic ID for CART
-    cart_instance_counter <- reactiveVal(0)
-    current_cart_module_id <- reactive({
-      paste0("cart_dynamic_instance_", cart_instance_counter())
-    })
+  
     
     # Observer for the main radio button (input$multiple)
     observeEvent(input$multiple, {
@@ -93,51 +68,6 @@ regressionAndCorrelationServer <- function(id) {
           req(current_logr_module_id())
           LogisticRegressionMainPanelUI(session$ns(current_logr_module_id()))
         })
-      } else if (input$multiple == "PCA") {
-      pca_instance_counter(pca_instance_counter() + 1)
-      output$regressionSidebarUI <- renderUI({
-         req(current_pca_module_id())
-         PCASidebarUI(session$ns(current_pca_module_id()))
-       })
-       output$regressionMainPanelUI <- renderUI({
-         req(current_pca_module_id())
-         PCAMainPanelUI(session$ns(current_pca_module_id()))
-       })
-      } else if (input$multiple == "KNN") {
-        knn_instance_counter(knn_instance_counter() + 1)
-        
-        output$regressionSidebarUI <- renderUI({
-          req(current_knn_module_id())
-          KNNSidebarUI(session$ns(current_knn_module_id()))
-        })
-        output$regressionMainPanelUI <- renderUI({
-          req(current_knn_module_id())
-          KNNMainPanelUI(session$ns(current_knn_module_id()))
-        })
-      } else if (input$multiple == "LDA") {
-        lda_instance_counter(lda_instance_counter() + 1)
-        
-        output$regressionSidebarUI <- renderUI({
-          req(current_lda_module_id())
-          LDASidebarUI(session$ns(current_lda_module_id()))
-        })
-        
-        output$regressionMainPanelUI <- renderUI({
-          req(current_lda_module_id())
-          LDAMainPanelUI(session$ns(current_lda_module_id()))
-        })
-      } else if (input$multiple == "CART") {
-        cart_instance_counter(cart_instance_counter() + 1)
-        
-        output$regressionSidebarUI <- renderUI({
-          req(current_cart_module_id())
-          CARTSidebarUI(session$ns(current_cart_module_id()))
-        })
-        
-        output$regressionMainPanelUI <- renderUI({
-          req(current_cart_module_id())
-          CARTMainPanelUI(session$ns(current_cart_module_id()))
-        })
       }
       }, ignoreNULL = FALSE, ignoreInit = FALSE) # Corrected this line
     
@@ -150,26 +80,6 @@ regressionAndCorrelationServer <- function(id) {
     observeEvent(current_logr_module_id(), {
       req(input$multiple == "LOGR")
       LogisticRegressionServer(current_logr_module_id())
-    }, ignoreNULL = TRUE)
-    
-     observeEvent(current_pca_module_id(), {
-       req(input$multiple == "PCA")
-       PCAServer(current_pca_module_id())
-     }, ignoreNULL = TRUE)
-    
-    observeEvent(current_knn_module_id(), {
-      req(input$multiple == "KNN")
-      KNNServer(current_knn_module_id())
-    }, ignoreNULL = TRUE)
-    
-    observeEvent(current_lda_module_id(), {
-      req(input$multiple == "LDA")
-      LDAServer(current_lda_module_id())
-    }, ignoreNULL = TRUE)
-    
-    observeEvent(current_cart_module_id(), {
-      req(input$multiple == "CART")
-      CARTServer(current_cart_module_id())
     }, ignoreNULL = TRUE)
     
   })

--- a/global.R
+++ b/global.R
@@ -108,6 +108,8 @@ source("R/kNearestNeighbors.R")
 source("R/linearDiscriminantAnalysis.R")
 source("R/principalComponentAnalysis.R")
 
+source("R/machineLearning.R")
+
 options(scipen = 999) # options(scipen = 0)
 ## options(shiny.reactlog = TRUE)
 

--- a/server.R
+++ b/server.R
@@ -6,4 +6,5 @@ server <- function(session, input, output) {
   sampSizeEstServer(id = "sse")
   statInfrServer(id = "si")
   regressionAndCorrelationServer(id = "rc")
+  machineLearningServer(id = "ml")
 }

--- a/ui.R
+++ b/ui.R
@@ -52,7 +52,8 @@ BODY <-
                           tabPanel("Statistical Inference",
                                    statInfrUI(id = "si")),
                           tabPanel("Regression and Correlation",
-                                   regressionAndCorrelationUI(id = "rc")))),
+                                   regressionAndCorrelationUI(id = "rc")),
+                          tabPanel("Machine Learning", machineLearningUI(id = "ml")))),
       tabPanel("Authors", authorsUI())
     )
   )


### PR DESCRIPTION
- Add a Machine Learning tab with PCA, KNN, LDA, and CART modules. 
- Kept the original modules in the Regression and correlation tab (Will remove in the next changes).
- Created R/machineLearning.R with shared module structure
- Wired into ui.R, server.R, and global.R. 
- removed 4 ML modules from Regression and correlation tab