### PR TITLE
Changes in ML tab

### DIFF
--- a/R/decisionTrees.R
+++ b/R/decisionTrees.R
@@ -446,6 +446,11 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
       
       accuracy <- sum(diag(confusion_mat)) / sum(confusion_mat)
       
+      class_dist_df     <- as.data.frame(table(analysis_df[[resp_col]]))
+      colnames(class_dist_df) <- c("Class", "Count")
+
+      cart_class_report <- knn_classification_report(analysis_df[[resp_col]], cart_pred)$report
+
       importance <- cart_fit$variable.importance
       if (is.null(importance)) {
         importance <- numeric(0)
@@ -469,7 +474,9 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
         response = resp_col,
         predictors = input$predictors,
         n = nrow(analysis_df),
-        importance = importance_df
+        importance = importance_df,
+        class_dist = class_dist_df,
+        class_report = cart_class_report
       )
       
       calc_results(res)
@@ -485,9 +492,17 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
         req(r)
         
         tagList(
-          tags$h4("Model Information"),
+          tags$h4("Model Summary"),
           tableOutput(session$ns("cartModelInfo")),
-          
+
+          tags$h4("Class Distribution (Full Dataset)"),
+          tableOutput(session$ns("cartClassDist")),
+          tags$hr(),
+
+          tags$h4("Classification Report"),
+          tableOutput(session$ns("cartClassReport")),
+          tags$hr(),
+
           tags$h4("Confusion Matrix"),
           tableOutput(session$ns("confusionMatrixResults"))
         )
@@ -496,7 +511,7 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
       output$cartModelInfo <- renderTable({
         r <- calc_results()
         req(r)
-        
+
         data.frame(
           Item = c(
             "Number of Classes",
@@ -518,18 +533,30 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
           ),
           check.names = FALSE
         )
-      }, rownames = FALSE)
-      
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
+      output$cartClassDist <- renderTable({
+        r <- calc_results()
+        req(r)
+        r$class_dist
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
+      output$cartClassReport <- renderTable({
+        r <- calc_results()
+        req(r)
+        r$class_report
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
       output$confusionMatrixResults <- renderTable({
         r <- calc_results()
         req(r)
-        
+
         cm <- as.data.frame.matrix(r$confusion)
         cm$Actual <- rownames(cm)
         cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
         rownames(cm) <- NULL
         cm
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
       
       output$treePlot <- renderPlot({
         r <- plot_results()

--- a/R/kNearestNeighbors.R
+++ b/R/kNearestNeighbors.R
@@ -44,7 +44,7 @@ knn_classification_report <- function(actual, predicted) {
     check.names = FALSE
   )
   
-  list(cm = as.data.frame(cm), report = report, accuracy = accuracy)
+  list(cm = cm, report = report, accuracy = accuracy)
 }
 
 
@@ -435,8 +435,10 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
       numeric_cols <- cols[sapply(df0, is.numeric)]
 
       pre_predictors <- intersect(shared_explanatory(), numeric_cols)
+      shared_resp    <- shared_response()
+      pre_response   <- if (isTruthy(shared_resp) && shared_resp %in% cols) shared_resp else character(0)
 
-      updatePickerInput(session, "response",   choices = cols,         selected = character(0))
+      updatePickerInput(session, "response",   choices = cols,         selected = pre_response)
       updatePickerInput(session, "predictors", choices = numeric_cols, selected = pre_predictors)
 
       if (isTruthy(input$split)) {
@@ -624,53 +626,83 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
         
         #evaluation metrics 
         metrics <- knn_classification_report(actual = y_test, predicted = pred)
-        
+
+        class_dist_df <- as.data.frame(table(as.factor(df[[resp_col]])))
+        colnames(class_dist_df) <- c("Class", "Count")
+
+        # nearest odd integer of sqrt(n_train) — recommended starting k
+        k_round_val   <- round(sqrt(n_train))
+        k_recommended <- if (k_round_val %% 2 == 0) k_round_val + 1L else as.integer(k_round_val)
+
         # to keep train/split static until user clicks calculate
         calc_settings(list(
-          split = input$split,
-          k = k,
-          n_total = n,
-          n_train = n_train
+          split         = input$split,
+          k             = k,
+          n_total       = n,
+          n_train       = n_train,
+          k_recommended = k_recommended
         ))
-        
-        
+
+
         #Results UI layout
         output$resultsUI <- renderUI({
           s <- calc_settings()
           req(s)
-          
-          split_prop <- s$split / 100
-          k_calc <- sqrt(s$n_train)
-          
+
           tagList(
-            shiny::withMathJax(),
-            
-            tags$p(tags$strong("Task: "), input$task),
-            
-            tags$p(tags$strong("n = "), s$n_total),
-            
-            tags$p(tags$strong("n × train split = "),
-                   paste0(s$n_total, " × ", sprintf("%.2f", split_prop), " = ", s$n_train)),
-            
-            tags$p(tags$strong("k calculation: "),
-                   sprintf("\\( k = \\sqrt{n_{train}} = \\sqrt{%s} = %.4f \\Rightarrow %s \\)",
-                           s$n_train, k_calc, s$k)),
-            
-            tags$p(tags$strong("k = "), s$k),
+            tags$h4("Model Summary"),
+            tags$p(HTML("<strong><em>n</em> = </strong>"), s$n_total),
             tags$p(tags$strong("Train split = "), paste0(s$split, "%")),
             tags$p(tags$strong("Accuracy = "), sprintf("%.4f", metrics$accuracy)),
-            
+
+            tags$hr(),
+
+            tags$h5(tags$strong(HTML("Your Selected <em>k</em>"))),
+            tags$p(HTML(paste0(
+              "You selected <em>k</em> = <strong>", s$k, "</strong>"
+            ))),
+
+            tags$h5(tags$strong(HTML("Recommended <em>k</em>"))),
+            tags$p(HTML(paste0(
+              "Based on your training set size, the recommended starting <em>k</em> is calculated as: ",
+              "&radic;<em>n</em><sub>train</sub>",
+              " = &radic;", s$n_train,
+              " = ", sprintf("%.2f", sqrt(s$n_train)),
+              " &asymp; <strong>", s$k_recommended, "</strong>"
+            ))),
+
+            tags$p(
+              style = "color: #6c757d; font-size: 14px; margin-top: 4px;",
+              HTML(paste0(
+                "The recommended <em>k</em> is a starting point. Your chosen <em>k</em> may perform ",
+                "better depending on your dataset. Always validate using the confusion matrix results."
+              ))
+            ),
+
+            tags$hr(),
+
+            tags$h4("Class Distribution (Full Dataset)"),
+            tableOutput(session$ns("classDist")),
+            tags$hr(),
+
             tags$h4("Classification Report"),
             tableOutput(session$ns("classReport")),
-            
+
             tags$h4("Confusion Matrix"),
             tableOutput(session$ns("confMat"))
           )
         })
         
         #send the data into the UI
+        output$classDist    <- renderTable({ class_dist_df }, rownames = FALSE, striped = TRUE, bordered = TRUE)
         output$classReport  <- renderTable({ metrics$report }, striped = TRUE, bordered = TRUE)
-        output$confMat      <- renderTable({ metrics$cm }, striped = TRUE, bordered = TRUE)
+        output$confMat <- renderTable({
+          cm <- as.data.frame.matrix(metrics$cm)
+          cm$Actual <- rownames(cm)
+          cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
+          rownames(cm) <- NULL
+          cm
+        }, rownames = FALSE, striped = TRUE, bordered = TRUE)
         
         plot_settings(list(
           response = resp_col,

--- a/R/linearDiscriminantAnalysis.R
+++ b/R/linearDiscriminantAnalysis.R
@@ -360,7 +360,9 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
       predictor_df <- analysis_df[, input$predictors, drop = FALSE]
       numeric_check <- sapply(predictor_df, is.numeric)
 
-      class_counts <- table(analysis_df[[resp_col]])
+      class_counts    <- table(analysis_df[[resp_col]])
+      class_dist_df   <- as.data.frame(class_counts)
+      colnames(class_dist_df) <- c("Class", "Count")
 
       if (nlevels(analysis_df[[resp_col]]) > floor(nrow(analysis_df) / 2)) {
         showNotification(
@@ -466,6 +468,9 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
         cv_accuracy <- sum(diag(cv_confusion)) / sum(cv_confusion)
       }
 
+      class_report_preds <- if (isTRUE(input$useCV)) lda_cv$class else lda_pred$class
+      lda_class_report   <- knn_classification_report(analysis_df[[resp_col]], class_report_preds)$report
+
       res <- list(
         fit = lda_fit,
         confusion = confusion_mat,
@@ -476,7 +481,9 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
         cv_accuracy = cv_accuracy,
         response = resp_col,
         predictors = input$predictors,
-        n = nrow(analysis_df)
+        n = nrow(analysis_df),
+        class_dist = class_dist_df,
+        class_report = lda_class_report
       )
 
       calc_results(res)
@@ -493,9 +500,17 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
         req(r)
 
         tagList(
-          tags$h4("Model Information"),
+          tags$h4("Model Summary"),
           tableOutput(session$ns("ldaModelInfo")),
-          
+
+          tags$h4("Class Distribution (Full Dataset)"),
+          tableOutput(session$ns("ldaClassDist")),
+          tags$hr(),
+
+          tags$h4("Classification Report"),
+          tableOutput(session$ns("ldaClassReport")),
+          tags$hr(),
+
           tags$h4("Prior Probabilities"),
           tableOutput(session$ns("ldaPriors")),
 
@@ -516,13 +531,13 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
       output$ldaModelInfo <- renderTable({
         r <- calc_results()
         req(r)
-        
+
         acc <- if (isTRUE(input$useCV) && !is.null(r$cv_accuracy)) {
           round(r$cv_accuracy, 4)
         } else {
           round(r$accuracy, 4)
         }
-        
+
         data.frame(
           Item = c(
             "Number of Classes",
@@ -540,57 +555,69 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
           ),
           check.names = FALSE
         )
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
       
+      output$ldaClassDist <- renderTable({
+        r <- calc_results()
+        req(r)
+        r$class_dist
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
+      output$ldaClassReport <- renderTable({
+        r <- calc_results()
+        req(r)
+        r$class_report
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
       output$ldaPriors <- renderTable({
         r <- calc_results()
         req(r)
-        
+
         data.frame(
           Class = names(r$fit$prior),
           Prior_Probability = round(as.numeric(r$fit$prior), 4),
           check.names = FALSE
         )
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
 
       output$groupMeans <- renderTable({
         r <- calc_results()
         req(r)
         round(r$fit$means, 4)
-      }, rownames = TRUE)
+      }, rownames = TRUE, striped = TRUE, bordered = TRUE)
 
       output$coefficients <- renderTable({
         r <- calc_results()
         req(r)
         round(r$fit$scaling, 4)
-      }, rownames = TRUE)
+      }, rownames = TRUE, striped = TRUE, bordered = TRUE)
 
       output$propTrace <- renderTable({
         r <- calc_results()
         req(r)
-        
+
         data.frame(
           Discriminant = paste0("LD", seq_along(r$prop_trace)),
           Proportion = round(r$prop_trace, 4),
           check.names = FALSE
         )
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
 
       output$confusionMatrix <- renderTable({
         r <- calc_results()
         req(r)
-        
+
         cm <- if (isTRUE(input$useCV) && !is.null(r$cv_confusion)) {
           as.data.frame.matrix(r$cv_confusion)
         } else {
           as.data.frame.matrix(r$confusion)
         }
-        
+
         cm$Actual <- rownames(cm)
         cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
         rownames(cm) <- NULL
         cm
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
 
       output$ldaPlot <- renderPlot({
         r <- plot_results()

--- a/R/machineLearning.R
+++ b/R/machineLearning.R
@@ -7,14 +7,14 @@ machineLearningUI <- function(id) {
       shinyjs::useShinyjs(),
       HTML(uploadDataDisclaimer),
       fileInput(ns("mlDataFile"),
-                tags$b("Upload Data (.csv, .tsv, .txt, .xls, .xlsx)"),
+                tags$b("Upload Data (.csv, .xls, .xlsx, or .txt)"),
                 accept = c("text/csv", "text/comma-separated-values", "text/plain",
                            ".csv", ".tsv", ".txt", ".xls", ".xlsx")),
       actionButton(
         ns("loadIris"),
         label = tagList(icon("seedling"), "Load Example Dataset (iris)"),
         class = "btn btn-outline-secondary btn-sm w-100",
-        style = "margin-top: -8px; margin-bottom: 6px;"
+        style = "margin-top: -8px; margin-bottom: 6px; border: 2px solid #aaa; border-radius: 4px;"
       ),
       uiOutput(ns("mlDataStatus")),
       radioButtons(ns("method"),

--- a/R/randomForest.R
+++ b/R/randomForest.R
@@ -82,6 +82,13 @@ RFMainPanelUI <- function(id) {
       ),
 
       tabPanel(
+        title = "Plots",
+        value = "plots_tab",
+        uiOutput(ns("rfVarImpContainer")),
+        uiOutput(ns("rfPDPContainer"))
+      ),
+
+      tabPanel(
         title = "Uploaded Data",
         value = "uploaded_data_tab",
         uiOutput(ns("uploadedDataContainer"))
@@ -124,6 +131,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
     # ---- Hide result tabs until Calculate succeeds ----
     session$onFlushed(function() {
       hideTab(inputId = "rfMainPanel", target = "model_summary_tab")
+      hideTab(inputId = "rfMainPanel", target = "plots_tab")
     }, once = TRUE)
 
     # ---- Uploaded Data tab ----
@@ -203,6 +211,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         rf_message(NULL)
 
         hideTab(inputId = "rfMainPanel", target = "model_summary_tab")
+        hideTab(inputId = "rfMainPanel", target = "plots_tab")
         updateNavbarPage(session, "rfMainPanel", selected = "uploaded_data_tab")
       },
       ignoreInit = TRUE
@@ -440,6 +449,29 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
       # 16. OOB error rate (final tree)
       oob_error <- rf_fit$err.rate[nrow(rf_fit$err.rate), "OOB"]
 
+      # 17. Classification report (test set)
+      rf_class_report <- knn_classification_report(test_df[[resp_col]], test_pred)$report
+
+      # 18. Partial dependence plots via iml (computed once, stored in res)
+      pdp_results <- tryCatch({
+        predictor_iml <- suppressWarnings(
+          iml::Predictor$new(
+            model            = rf_fit,
+            data             = train_df[, input$predictors, drop = FALSE],
+            y                = train_df[[resp_col]],
+            predict.function = function(model, newdata) predict(model, newdata, type = "prob")
+          )
+        )
+        pdp_list <- suppressWarnings(lapply(input$predictors, function(pvar) {
+          tryCatch(
+            iml::FeatureEffect$new(predictor_iml, feature = pvar, method = "pdp")$results,
+            error = function(e) NULL
+          )
+        }))
+        names(pdp_list) <- input$predictors
+        pdp_list
+      }, error = function(e) NULL)
+
       res <- list(
         fit           = rf_fit,
         train_df      = train_df,
@@ -455,7 +487,9 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         oob_error     = oob_error,
         confusion     = confusion_mat,
         accuracy      = accuracy,
-        class_metrics = class_metrics_df
+        class_metrics = class_metrics_df,
+        class_report  = rf_class_report,
+        pdp_results   = pdp_results
       )
 
       calc_results(res)
@@ -470,11 +504,14 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         accuracy_label <- if (r$oob_error < 0.10) "high" else if (r$oob_error <= 0.25) "moderate" else "low"
 
         tagList(
-          tags$h4("Random Forest Model Summary"),
+          tags$h4("Model Summary"),
           uiOutput(session$ns("rfSummaryTable")),
           tags$hr(),
           tags$h4("Class Distribution (Full Dataset)"),
           tableOutput(session$ns("rfClassDistTable")),
+          tags$hr(),
+          tags$h4("Classification Report (Test Set)"),
+          tableOutput(session$ns("rfClassReport")),
           tags$hr(),
           tags$h4("Confusion Matrix (Test Set)"),
           tableOutput(session$ns("rfConfusionTable")),
@@ -576,7 +613,13 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
         r$class_dist
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
+      output$rfClassReport <- renderTable({
+        r <- calc_results()
+        req(r)
+        r$class_report
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
 
       output$rfConfusionTable <- renderTable({
         r <- calc_results()
@@ -586,19 +629,169 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
         rownames(cm) <- NULL
         cm
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
 
       output$rfClassMetrics <- renderTable({
         r <- calc_results()
         req(r)
         r$class_metrics
-      }, rownames = FALSE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
+      output$rfVarImpContainer <- renderUI({
+        tagList(
+          tags$h4("Variable Importance Plots", style = "margin-top: 10px;"),
+          plotOutput(session$ns("rfVarImpPlot"), height = "550px")
+        )
+      })
+
+      output$rfVarImpPlot <- renderPlot({
+        r <- calc_results()
+        req(r)
+
+        imp_acc  <- randomForest::importance(r$fit, type = 1)
+        imp_gini <- randomForest::importance(r$fit, type = 2)
+
+        df_acc <- data.frame(
+          Variable = rownames(imp_acc),
+          Value    = imp_acc[, 1],
+          stringsAsFactors = FALSE
+        )
+        df_acc <- df_acc[order(df_acc$Value, decreasing = FALSE), ]
+
+        df_gini <- data.frame(
+          Variable = rownames(imp_gini),
+          Value    = imp_gini[, 1],
+          stringsAsFactors = FALSE
+        )
+        df_gini <- df_gini[order(df_gini$Value, decreasing = FALSE), ]
+
+        max_chars <- max(nchar(c(df_acc$Variable, df_gini$Variable)), na.rm = TRUE)
+        left_mar  <- max(4, ceiling(max_chars * 0.6))
+
+        par(
+          mfrow = c(1, 2),
+          oma   = c(0, 0, 0, 0),
+          mar   = c(5, left_mar, 4, 2)
+        )
+
+        barplot(
+          df_acc$Value,
+          names.arg = df_acc$Variable,
+          horiz     = TRUE,
+          las       = 1,
+          col       = "#4472C4",
+          main      = "Mean Decrease in Accuracy",
+          xlab      = "Mean Decrease in Accuracy",
+          cex.main  = 1.3,
+          font.main = 2,
+          cex.lab   = 1.1,
+          font.lab  = 2,
+          cex.names = 0.95
+        )
+
+        barplot(
+          df_gini$Value,
+          names.arg = df_gini$Variable,
+          horiz     = TRUE,
+          las       = 1,
+          col       = "#ED7D31",
+          main      = "Mean Decrease in Gini Impurity",
+          xlab      = "Mean Decrease in Gini",
+          cex.main  = 1.3,
+          font.main = 2,
+          cex.lab   = 1.1,
+          font.lab  = 2,
+          cex.names = 0.95
+        )
+      })
+
+      # Dynamic container: sets height based on predictor count then renders plotOutput
+      output$rfPDPContainer <- renderUI({
+        r <- calc_results()
+        req(r, !is.null(r$pdp_results))
+
+        n_pred    <- length(r$predictors)
+        n_cols    <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
+        n_rows    <- ceiling(n_pred / n_cols)
+        height_px <- max(300, n_rows * 300)
+
+        tagList(
+          tags$hr(),
+          tags$h4("Partial Dependence Plots", style = "margin-top: 10px;"),
+          plotOutput(session$ns("rfPDPPlot"), height = paste0(height_px, "px"))
+        )
+      })
+
+      output$rfPDPPlot <- renderPlot({
+        r <- calc_results()
+        req(r, !is.null(r$pdp_results))
+
+        n_pred  <- length(r$predictors)
+        n_cols  <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
+        n_rows  <- ceiling(n_pred / n_cols)
+
+        cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")
+
+        par(
+          mfrow = c(n_rows, n_cols),
+          oma   = c(0, 0, 0, 0),
+          mar   = c(4, 4, 5, 2)
+        )
+
+        for (pred_var in r$predictors) {
+          pdp_df <- r$pdp_results[[pred_var]]
+
+          if (is.null(pdp_df)) {
+            plot.new()
+            title(main = pred_var, cex.main = 1.1, font.main = 2)
+            text(0.5, 0.5, "Could not compute PDP", cex = 0.9)
+            next
+          }
+
+          cls_list <- as.character(unique(pdp_df$.class))
+
+          plot(
+            x    = NULL,
+            xlim = range(pdp_df[[pred_var]], na.rm = TRUE),
+            ylim = c(0, 1),
+            main = pred_var,
+            xlab = pred_var,
+            ylab = "Predicted Probability",
+            cex.main = 1.1,
+            font.main = 2,
+            cex.lab  = 0.95,
+            font.lab = 2,
+            cex.axis = 0.9
+          )
+
+          for (j in seq_along(cls_list)) {
+            cls_df <- pdp_df[as.character(pdp_df$.class) == cls_list[j], ]
+            cls_df <- cls_df[order(cls_df[[pred_var]]), ]
+            lines(cls_df[[pred_var]], cls_df$.value,
+                  col = cls_cols[j], lwd = 2)
+          }
+
+          legend("topright", legend = cls_list,
+                 col = cls_cols[seq_along(cls_list)],
+                 lwd = 2, bty = "n", cex = 0.8)
+
+          mtext("Shows the marginal effect of this variable on the predicted outcome,",
+                side = 3, line = 0.9, cex = 0.65, col = "#555555")
+          mtext("holding all other variables constant",
+                side = 3, line = 0.2, cex = 0.65, col = "#555555")
+        }
+
+        # blank out remaining grid cells for odd predictor counts
+        remaining <- n_rows * n_cols - n_pred
+        for (k in seq_len(remaining)) plot.new()
+      })
 
       # ---- Show tabs and navigate ----
       summary_ready(TRUE)
       summary_ever_calculated(TRUE)
 
       showTab(inputId = "rfMainPanel", target = "model_summary_tab")
+      showTab(inputId = "rfMainPanel", target = "plots_tab")
 
       shinyjs::delay(100, {
         updateNavbarPage(session, "rfMainPanel", selected = "model_summary_tab")
@@ -609,6 +802,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
     # ---- Reset ----
     observeEvent(input$reset, {
       hideTab(inputId = "rfMainPanel", target = "model_summary_tab")
+      hideTab(inputId = "rfMainPanel", target = "plots_tab")
 
       summary_ready(FALSE)
       summary_ever_calculated(FALSE)


### PR DESCRIPTION
 - Changed file upload label from .csv, .tsv, .txt, .xls, .xlsx to .csv, .xls, .xlsx, or .txt
 - Added a visible border (2px solid #aaa) to the Load Example Dataset button

- When switching back to KNN after using another method, the response variable picker now pre-populates from shared_response() instead of always resetting to empty
- Confusion matrix format — changed from long format (actual/predicted/Freq columns) to wide      format, matching all other methods;
- replaced the single misleading "k calculation" line with two clearly labelled sections: Your
  Selected k and Recommended k.
- Table stylingg, applied striped+ bordered consistently to all results tables
- Class Distribution table + Classification Report for LDA and decisiontree
Randomforest tab:
- Classification Report
- plot tab not hidden any more
- Variable Importance Plots (Added safely)
- Partial Dependence Plots (Added safely)