### PR TITLE
Changes to ML tab

### DIFF
--- a/R/decisionTrees.R
+++ b/R/decisionTrees.R
@@ -65,9 +65,10 @@ CARTSidebarUI <- function(id) {
 
 CARTMainPanelUI <- function(id) {
   ns <- NS(id)
-  
+
   tagList(
     useShinyjs(),
+    suppressWarnings(tippy::use_tippy()),
     navbarPage(
       title = NULL,
       
@@ -491,9 +492,13 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
         
+        correct <- sum(diag(r$confusion))
+        total   <- sum(r$confusion)
+
         tagList(
           tags$h4("Model Summary"),
           tableOutput(session$ns("cartModelInfo")),
+          tags$hr(),
 
           tags$h4("Class Distribution (Full Dataset)"),
           tableOutput(session$ns("cartClassDist")),
@@ -501,10 +506,19 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
 
           tags$h4("Classification Report"),
           tableOutput(session$ns("cartClassReport")),
+          tags$script(HTML("setTimeout(function(){ if(typeof tippy!=='undefined') tippy('[data-tippy-content]'); }, 200);")),
           tags$hr(),
 
           tags$h4("Confusion Matrix"),
-          tableOutput(session$ns("confusionMatrixResults"))
+          tableOutput(session$ns("confusionMatrixResults")),
+          tags$h5(tags$strong("Accuracy Calculation"),
+                  style = "margin-top: 14px; margin-bottom: 2px;"),
+          withMathJax(
+            tags$p(sprintf(
+              "\\[ \\text{Accuracy} = \\frac{\\text{Correct Predictions}}{\\text{Total Observations}} = \\frac{%d}{%d} = %.2f\\%% \\]",
+              correct, total, r$accuracy * 100
+            ))
+          )
         )
       })
       
@@ -545,18 +559,40 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
         r$class_report
-      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+         sanitize.colnames.function = function(x) {
+           tips <- c(
+             Precision = "Of all instances predicted as this class, the fraction that are truly this class. High precision means few false positives.",
+             Recall    = "Of all actual instances of this class, the fraction correctly predicted. High recall means few false negatives.",
+             F1        = "Harmonic mean of Precision and Recall — balances both into a single score.",
+             Support   = "Number of actual instances of this class in the dataset."
+           )
+           sapply(x, function(col) {
+             if (col %in% names(tips)) {
+               paste0('<b><span data-tippy-content="', tips[[col]],
+                      '" style="cursor:help;border-bottom:1px dotted #555;">', col, '</span></b>')
+             } else {
+               paste0("<b>", col, "</b>")
+             }
+           }, USE.NAMES = FALSE)
+         })
 
       output$confusionMatrixResults <- renderTable({
         r <- calc_results()
         req(r)
 
         cm <- as.data.frame.matrix(r$confusion)
-        cm$Actual <- rownames(cm)
+        cm$Actual <- paste0("<b>", rownames(cm), "</b>")
         cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
         rownames(cm) <- NULL
         cm
-      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+         sanitize.text.function = identity,
+         sanitize.colnames.function = function(x) {
+           sapply(x, function(col) {
+             if (col == "Actual") "<b>Actual \\ Predicted</b>" else paste0("<b>", col, "</b>")
+           }, USE.NAMES = FALSE)
+         })
       
       output$treePlot <- renderPlot({
         r <- plot_results()
@@ -581,32 +617,34 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
       output$varImportancePlot <- renderPlot({
         r <- plot_results()
         req(r)
-        
+
         if (nrow(r$importance) == 0) {
           plot.new()
-          text(0.5, 0.5, "No variable importance available for this model.")
+          text(0.5, 0.5, "No variable importance available for this model.",
+               cex = 0.9, col = "#555555")
           return()
         }
-        
-        imp_df <- r$importance
-        imp_df$Variable <- factor(imp_df$Variable, levels = rev(imp_df$Variable))
-        
-        ggplot(imp_df, aes(x = ImportancePct, y = Variable)) +
-          geom_col(fill = "#18536F") +
-          labs(
-            title = "Variable Importance",
-            x = "Importance (%)",
-            y = "Predictor"
-          ) +
-          scale_x_continuous(labels = function(x) paste0(round(x, 1), "%")) +
-          theme_bw() +
-          theme(
-            plot.title = element_text(hjust = 0.5, face = "bold", size = 18),
-            axis.title.x = element_text(face = "bold", size = 14),
-            axis.title.y = element_text(face = "bold", size = 14),
-            axis.text.x = element_text(face = "bold", size = 12),
-            axis.text.y = element_text(face = "bold", size = 12)
-          )
+
+        imp_df    <- r$importance[order(r$importance$ImportancePct, decreasing = FALSE), ]
+        max_chars <- max(nchar(imp_df$Variable), na.rm = TRUE)
+        left_mar  <- max(4, ceiling(max_chars * 0.6))
+
+        par(mar = c(5, left_mar, 4, 2))
+
+        barplot(
+          imp_df$ImportancePct,
+          names.arg = imp_df$Variable,
+          horiz     = TRUE,
+          las       = 1,
+          col       = "#18536F",
+          main      = "Variable Importance",
+          xlab      = "Importance (%)",
+          cex.main  = 1.3,
+          font.main = 2,
+          cex.lab   = 1.1,
+          font.lab  = 2,
+          cex.names = 0.95
+        )
       })
       
       showTab(inputId = "cartMainPanel", target = "results_tab")

--- a/R/kNearestNeighbors.R
+++ b/R/kNearestNeighbors.R
@@ -107,6 +107,16 @@ KNNSidebarUI <- function(id) {
       uiOutput(ns("predictorsError"))
     ),
     
+    br(),
+    p(strong("Graph Options")),
+    hr(),
+    checkboxInput(
+      ns("showBoundary"),
+      label = "Decision Boundary Plot",
+      value = FALSE
+    ),
+    uiOutput(ns("boundaryVarUI")),
+
     uiOutput(ns("fileImportUserMessage")),
     actionButton(ns("calculate"), "Calculate", class = "act-btn"),
     actionButton(ns("reset"), "Reset Values", class = "act-btn")
@@ -115,9 +125,10 @@ KNNSidebarUI <- function(id) {
 
 KNNMainPanelUI <- function(id) {
   ns <- NS(id)
-  
+
   tagList(
     useShinyjs(),
+    suppressWarnings(tippy::use_tippy()),
     navbarPage(
       title = NULL,
 
@@ -193,92 +204,42 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
     # 1) Class distribution
     output$knnPlotClass <- renderPlot({
       pd <- plot_data()
-      y <- pd$y
-      
+      y  <- pd$y
+
       validate(
         need(nlevels(y) >= 2, "Choose a categorical response variable to plot class distribution.")
       )
-      
+
+      n_cls    <- nlevels(y)
+      cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")[seq_len(min(n_cls, 5))]
+
       plot(
         y,
-        main = "Class Distribution",
-        xlab = "Class",
-        ylab = "Frequency",
-        cex.main = 1.5,
+        col       = cls_cols,
+        main      = "Class Distribution",
+        xlab      = "Class",
+        ylab      = "Frequency",
+        cex.main  = 1.3,
         font.main = 2,
-        cex.lab = 1.3,
-        font.lab = 2,
-        cex.axis = 1.0,
-        xaxt = "n"
+        cex.lab   = 1.1,
+        font.lab  = 2,
+        cex.axis  = 1.0,
+        xaxt      = "n"
       )
-      
+
       axis(
-        side = 1,
-        at = seq_along(levels(y)),
-        labels = levels(y),
-        cex.axis = 1.2,
-        font = 1,
-        lwd = 1,
+        side      = 1,
+        at        = seq_along(levels(y)),
+        labels    = levels(y),
+        cex.axis  = 1.0,
+        font      = 1,
+        lwd       = 1,
         lwd.ticks = 1
       )
-      
+
       box(bty = "l")
     })
-    # 2) Box plots
-    output$knnPlotBox <- renderPlot({
-      pd <- plot_data()
-      
-      validate(
-        need(nlevels(pd$y) >= 2, "Choose a categorical response variable for classification plots.")
-      )
-      
-      p <- caret::featurePlot(x = pd$x, y = pd$y, plot = "box")
-      
-      grid::grid.newpage()
-      print(p)
-    }, res = 96)
-    
-    # 3) Density plots
-    output$knnPlotDensity <- renderPlot({
-      pd <- plot_data()
-      
-      validate(
-        need(nlevels(pd$y) >= 2, "Choose a categorical response variable for classification plots.")
-      )
-      
-      scales <- list(x = list(relation = "free"), y = list(relation = "free"))
-      
-      p <- caret::featurePlot(
-        x = pd$x,
-        y = pd$y,
-        plot = "density",
-        scales = scales,
-        auto.key = list(
-          columns = length(levels(pd$y)),
-          title = "Class",
-          cex.title = 1,
-          cex = 1,
-          space = "bottom"
-        ),
-      )
-      
-      p <- update(
-        p,
-        main = "Density Plots by Class",
-        xlab = "Feature",
-        ylab = "Density",
-        par.settings = list(
-          axis.text = list(cex = 1.1),
-          par.xlab.text = list(cex = 1.3, font = 2),
-          par.ylab.text = list(cex = 1.3, font = 2),
-          par.main.text = list(cex = 1.5, font = 2)
-        )
-      )
-      
-      grid::grid.newpage()
-      print(p)
-      
-    }, res = 96)
+
     
     # ---- Validation (k required, must be > 0) ----
     knn_iv <- shinyvalidate::InputValidator$new()
@@ -385,23 +346,55 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
         ))
       }
       
-      tagList(
-        tags$h4("Class Distribution"),
-        plotOutput(session$ns("knnPlotClass"), height = "350px"),
-        
-        tags$hr(),
-        
-        tags$h4("Boxplots by Class"),
-        plotOutput(session$ns("knnPlotBox"), height = "600px"),
-        
-        tags$hr(),
-        
-        tags$h4("Density Plots by Class"),
-        plotOutput(session$ns("knnPlotDensity"), height = "600px")
-      )
+      {
+        s <- plot_settings()
+        show_boundary <- !is.null(s) && isTRUE(s$showBoundary) && !is.null(s$boundaryVars)
+
+        tagList(
+          tags$h4("Class Distribution"),
+          plotOutput(session$ns("knnPlotClass"), height = "350px"),
+
+          if (show_boundary) tagList(
+            tags$hr(),
+            tags$h4("Decision Boundary"),
+            plotOutput(session$ns("knnPlotBoundary"), height = "500px")
+          ),
+
+          tags$hr(),
+
+          tags$h4("Accuracy vs k"),
+          plotOutput(session$ns("knnPlotAccVsK"), height = "400px")
+        )
+      }
     })
     
     
+    output$boundaryVarUI <- renderUI({
+      req(isTRUE(input$showBoundary))
+      preds <- input$predictors
+
+      if (length(preds) < 2) {
+        return(tags$p(
+          style = "font-size: 13px; color: #6c757d; margin-top: 4px;",
+          "Select at least 2 explanatory variables to use this plot."
+        ))
+      }
+
+      pickerInput(
+        session$ns("boundaryVars"),
+        label   = strong("Select 2 Variables for Axes"),
+        choices  = preds,
+        selected = head(preds, 2),
+        multiple = TRUE,
+        options  = list(
+          `max-options`      = 2,
+          `max-options-text` = "Select exactly 2 variables",
+          `live-search`      = TRUE,
+          title              = "Select exactly 2 variables"
+        )
+      )
+    })
+
     output$responseError <- renderUI({
       if (responseError()) {
         tags$div(
@@ -646,14 +639,14 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
 
         #Results UI layout
         output$resultsUI <- renderUI({
-          s <- calc_settings()
+          s       <- calc_settings()
           req(s)
+          correct <- sum(diag(metrics$cm))
+          total   <- sum(metrics$cm)
 
           tagList(
             tags$h4("Model Summary"),
-            tags$p(HTML("<strong><em>n</em> = </strong>"), s$n_total),
-            tags$p(tags$strong("Train split = "), paste0(s$split, "%")),
-            tags$p(tags$strong("Accuracy = "), sprintf("%.4f", metrics$accuracy)),
+            tableOutput(session$ns("knnModelInfo")),
 
             tags$hr(),
 
@@ -687,33 +680,230 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
 
             tags$h4("Classification Report"),
             tableOutput(session$ns("classReport")),
+            tags$script(HTML("setTimeout(function(){ if(typeof tippy!=='undefined') tippy('[data-tippy-content]'); }, 200);")),
 
             tags$h4("Confusion Matrix"),
-            tableOutput(session$ns("confMat"))
+            tableOutput(session$ns("confMat")),
+            tags$h5(tags$strong("Accuracy Calculation"),
+                    style = "margin-top: 14px; margin-bottom: 2px;"),
+            withMathJax(
+              tags$p(sprintf(
+                "\\[ \\text{Accuracy} = \\frac{\\text{Correct Predictions}}{\\text{Total Observations}} = \\frac{%d}{%d} = %.2f\\%% \\]",
+                correct, total, metrics$accuracy * 100
+              ))
+            )
           )
         })
         
         #send the data into the UI
+        output$knnModelInfo <- renderTable({
+          s <- calc_settings()
+          req(s)
+
+          data.frame(
+            Item = c(
+              "Number of Observations",
+              "Training Observations",
+              "Test Observations",
+              "Train/Test Split",
+              "Selected k",
+              "Recommended k",
+              "Accuracy"
+            ),
+            Value = c(
+              as.character(s$n_total),
+              as.character(s$n_train),
+              as.character(s$n_total - s$n_train),
+              paste0(s$split, "%"),
+              as.character(s$k),
+              as.character(s$k_recommended),
+              sprintf("%.4f", metrics$accuracy)
+            ),
+            check.names = FALSE
+          )
+        }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+
         output$classDist    <- renderTable({ class_dist_df }, rownames = FALSE, striped = TRUE, bordered = TRUE)
-        output$classReport  <- renderTable({ metrics$report }, striped = TRUE, bordered = TRUE)
+        output$classReport <- renderTable({
+          metrics$report
+        }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+           sanitize.colnames.function = function(x) {
+             tips <- c(
+               Precision = "Of all instances predicted as this class, the fraction that are truly this class. High precision means few false positives.",
+               Recall    = "Of all actual instances of this class, the fraction correctly predicted. High recall means few false negatives.",
+               F1        = "Harmonic mean of Precision and Recall — balances both into a single score.",
+               Support   = "Number of actual instances of this class in the dataset."
+             )
+             sapply(x, function(col) {
+               if (col %in% names(tips)) {
+                 paste0('<b><span data-tippy-content="', tips[[col]],
+                        '" style="cursor:help;border-bottom:1px dotted #555;">', col, '</span></b>')
+               } else {
+                 paste0("<b>", col, "</b>")
+               }
+             }, USE.NAMES = FALSE)
+           })
         output$confMat <- renderTable({
           cm <- as.data.frame.matrix(metrics$cm)
-          cm$Actual <- rownames(cm)
+          cm$Actual <- paste0("<b>", rownames(cm), "</b>")
           cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
           rownames(cm) <- NULL
           cm
-        }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+        }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+           sanitize.text.function = identity,
+           sanitize.colnames.function = function(x) {
+             sapply(x, function(col) {
+               if (col == "Actual") "<b>Actual \\ Predicted</b>" else paste0("<b>", col, "</b>")
+             }, USE.NAMES = FALSE)
+           })
         
+        boundary_vars <- if (isTRUE(input$showBoundary) &&
+                             length(input$boundaryVars) == 2) input$boundaryVars else NULL
+
         plot_settings(list(
-          response = resp_col,
-          predictors = input$predictors
+          response     = resp_col,
+          predictors   = input$predictors,
+          X_train      = X_train,
+          X_test       = X_test,
+          y_train      = y_train,
+          y_test       = y_test,
+          k            = k,
+          showBoundary = isTRUE(input$showBoundary),
+          boundaryVars = boundary_vars
         ))
         
+        output$knnPlotBoundary <- renderPlot({
+          s <- plot_settings()
+          req(s, !is.null(s$boundaryVars), length(s$boundaryVars) == 2)
+
+          p1 <- s$boundaryVars[1]
+          p2 <- s$boundaryVars[2]
+
+          X_tr <- s$X_train[, c(p1, p2), drop = FALSE]
+          X_te <- s$X_test[,  c(p1, p2), drop = FALSE]
+
+          x1_rng <- range(c(X_tr[, 1], X_te[, 1]), na.rm = TRUE)
+          x2_rng <- range(c(X_tr[, 2], X_te[, 2]), na.rm = TRUE)
+          pad    <- 0.1
+
+          x1_seq <- seq(x1_rng[1] - pad * diff(x1_rng),
+                        x1_rng[2] + pad * diff(x1_rng), length.out = 80)
+          x2_seq <- seq(x2_rng[1] - pad * diff(x2_rng),
+                        x2_rng[2] + pad * diff(x2_rng), length.out = 80)
+
+          grid_mat           <- as.matrix(expand.grid(x1_seq, x2_seq))
+          colnames(grid_mat) <- c(p1, p2)
+
+          grid_pred <- suppressWarnings(class::knn(
+            train = X_tr, test = grid_mat, cl = s$y_train, k = s$k
+          ))
+
+          classes  <- levels(s$y_train)
+          n_cls    <- length(classes)
+          cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")[seq_len(min(n_cls, 5))]
+
+          # Lighten region colours toward white so they remain visible on both
+          # light and dark backgrounds without relying on alpha blending
+          lighten <- function(col, f = 0.55) {
+            v <- col2rgb(col) / 255
+            v <- v + (1 - v) * f
+            rgb(v[1, ], v[2, ], v[3, ])
+          }
+          bg_cols <- lighten(cls_cols)
+
+          class_idx <- match(as.character(grid_pred), classes)
+          z_mat     <- matrix(class_idx, nrow = length(x1_seq), ncol = length(x2_seq))
+          breaks    <- seq(0.5, n_cls + 0.5, by = 1)
+
+          par(mar = c(5, 4, 4, 2), cex.main = 1.3, font.main = 2,
+              cex.lab = 1.1, font.lab = 2, cex.axis = 1.0)
+
+          image(
+            x1_seq, x2_seq, z_mat,
+            col    = bg_cols,
+            breaks = breaks,
+            main   = paste0("Decision Boundary (", p1, " vs ", p2, ")"),
+            xlab   = p1,
+            ylab   = p2
+          )
+
+          box(bty = "l")
+
+          all_X2  <- rbind(X_tr, X_te)
+          all_y   <- c(as.character(s$y_train), as.character(s$y_test))
+          all_col <- cls_cols[match(all_y, classes)]
+          points(all_X2[, 1], all_X2[, 2], col = all_col, pch = 19, cex = 0.9)
+
+          legend(
+            "topright",
+            legend = classes,
+            col    = cls_cols[seq_along(classes)],
+            pch    = 19,
+            pt.cex = 0.9,
+            bty    = "n",
+            cex    = 0.95,
+            title  = "Class"
+          )
+        })
+
+        output$knnPlotAccVsK <- renderPlot({
+          s <- plot_settings()
+          req(s)
+
+          max_k  <- max(s$k + 5, min(50, nrow(s$X_train) - 1))
+          k_vals <- seq_len(max_k)
+
+          acc_vals <- sapply(k_vals, function(ki) {
+            pred <- suppressWarnings(class::knn(
+              train = s$X_train, test = s$X_test, cl = s$y_train, k = ki
+            ))
+            mean(pred == s$y_test)
+          })
+
+          par(mar = c(5, 4, 4, 2))
+
+          plot(
+            k_vals, acc_vals,
+            type      = "l",
+            col       = "#4472C4",
+            lwd       = 2,
+            main      = "Accuracy vs k",
+            xlab      = "k (Number of Neighbors)",
+            ylab      = "Test Set Accuracy",
+            ylim      = c(max(0, min(acc_vals) - 0.05), min(1, max(acc_vals) + 0.05)),
+            cex.main  = 1.3,
+            font.main = 2,
+            cex.lab   = 1.1,
+            font.lab  = 2,
+            cex.axis  = 1.0,
+            bty       = "l"
+          )
+
+          points(k_vals, acc_vals, pch = 19, col = "#4472C4", cex = 0.6)
+
+          if (s$k <= max_k) {
+            points(s$k, acc_vals[s$k], col = "#ED7D31", pch = 19, cex = 1.8)
+            abline(v = s$k, col = "#ED7D31", lty = 2, lwd = 1.5)
+          }
+
+          legend(
+            "topright",
+            legend = c("Accuracy", paste0("Selected k = ", s$k)),
+            col    = c("#4472C4", "#ED7D31"),
+            lty    = c(1, 2),
+            pch    = c(19, 19),
+            pt.cex = c(0.6, 1.5),
+            lwd    = c(2, 1.5),
+            bty    = "n",
+            cex    = 0.95
+          )
+        })
+
         results_ready(TRUE)
         plots_ready(TRUE)
         results_ever_calculated(TRUE)
         plots_ever_calculated(TRUE)
-        
+
         showTab(inputId = "knnMainPanel", target = "results_tab")
         showTab(inputId = "knnMainPanel", target = "plots_tab")
         

--- a/R/linearDiscriminantAnalysis.R
+++ b/R/linearDiscriminantAnalysis.R
@@ -52,6 +52,7 @@ LDAMainPanelUI <- function(id) {
 
   tagList(
     useShinyjs(),
+    suppressWarnings(tippy::use_tippy()),
     navbarPage(
       title = NULL,
 
@@ -499,9 +500,15 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
 
+        conf_used <- if (isTRUE(input$useCV) && !is.null(r$cv_confusion)) r$cv_confusion else r$confusion
+        acc_used  <- if (isTRUE(input$useCV) && !is.null(r$cv_accuracy))  r$cv_accuracy  else r$accuracy
+        correct   <- sum(diag(conf_used))
+        total     <- sum(conf_used)
+
         tagList(
           tags$h4("Model Summary"),
           tableOutput(session$ns("ldaModelInfo")),
+          tags$hr(),
 
           tags$h4("Class Distribution (Full Dataset)"),
           tableOutput(session$ns("ldaClassDist")),
@@ -509,6 +516,19 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
 
           tags$h4("Classification Report"),
           tableOutput(session$ns("ldaClassReport")),
+          tags$script(HTML("setTimeout(function(){ if(typeof tippy!=='undefined') tippy('[data-tippy-content]'); }, 200);")),
+          tags$hr(),
+
+          tags$h4("Confusion Matrix"),
+          tableOutput(session$ns("confusionMatrix")),
+          tags$h5(tags$strong("Accuracy Calculation"),
+                  style = "margin-top: 14px; margin-bottom: 2px;"),
+          withMathJax(
+            tags$p(sprintf(
+              "\\[ \\text{Accuracy} = \\frac{\\text{Correct Predictions}}{\\text{Total Observations}} = \\frac{%d}{%d} = %.2f\\%% \\]",
+              correct, total, acc_used * 100
+            ))
+          ),
           tags$hr(),
 
           tags$h4("Prior Probabilities"),
@@ -521,10 +541,7 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
           tableOutput(session$ns("coefficients")),
 
           tags$h4("Proportion of Trace"),
-          tableOutput(session$ns("propTrace")),
-
-          tags$h4("Confusion Matrix"),
-          tableOutput(session$ns("confusionMatrix"))
+          tableOutput(session$ns("propTrace"))
         )
       })
 
@@ -567,7 +584,23 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
         r$class_report
-      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+         sanitize.colnames.function = function(x) {
+           tips <- c(
+             Precision = "Of all instances predicted as this class, the fraction that are truly this class. High precision means few false positives.",
+             Recall    = "Of all actual instances of this class, the fraction correctly predicted. High recall means few false negatives.",
+             F1        = "Harmonic mean of Precision and Recall — balances both into a single score.",
+             Support   = "Number of actual instances of this class in the dataset."
+           )
+           sapply(x, function(col) {
+             if (col %in% names(tips)) {
+               paste0('<b><span data-tippy-content="', tips[[col]],
+                      '" style="cursor:help;border-bottom:1px dotted #555;">', col, '</span></b>')
+             } else {
+               paste0("<b>", col, "</b>")
+             }
+           }, USE.NAMES = FALSE)
+         })
 
       output$ldaPriors <- renderTable({
         r <- calc_results()
@@ -613,38 +646,57 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
           as.data.frame.matrix(r$confusion)
         }
 
-        cm$Actual <- rownames(cm)
+        cm$Actual <- paste0("<b>", rownames(cm), "</b>")
         cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
         rownames(cm) <- NULL
         cm
-      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+         sanitize.text.function = identity,
+         sanitize.colnames.function = function(x) {
+           sapply(x, function(col) {
+             if (col == "Actual") "<b>Actual \\ Predicted</b>" else paste0("<b>", col, "</b>")
+           }, USE.NAMES = FALSE)
+         })
 
       output$ldaPlot <- renderPlot({
         r <- plot_results()
         req(r)
 
-        ggplot(r$scores, aes(x = LD1, y = LD2, color = Class)) +
-          geom_point(size = 3, alpha = 0.8) +
-          labs(
-            title = "LDA Plot",
-            x = "LD1",
-            y = "LD2",
-            color = "Class"
-          ) +
-          theme_bw() +
-          theme(
-            plot.title = element_text(hjust = 0.5, face = "bold", size = 18),
+        scores   <- r$scores
+        classes  <- as.character(levels(scores$Class))
+        n_cls    <- length(classes)
+        cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")[seq_len(min(n_cls, 5))]
+        col_vec  <- cls_cols[match(as.character(scores$Class), classes)]
 
-            axis.title.x = element_text(face = "bold", size = 14),
-            axis.title.y = element_text(face = "bold", size = 14),
-  
-            axis.text.x = element_text(face = "bold", size = 14),
-            axis.text.y = element_text(face = "bold", size = 14),
+        par(mar = c(5, 4, 4, 2))
 
-            legend.title = element_text(size = 14, face = "bold"),
-            
-            legend.text = element_text(size = 12)
-          )
+        plot(
+          scores$LD1,
+          scores$LD2,
+          col       = col_vec,
+          pch       = 19,
+          cex       = 1.1,
+          main      = "LDA Plot",
+          xlab      = "LD1",
+          ylab      = "LD2",
+          cex.main  = 1.3,
+          font.main = 2,
+          cex.lab   = 1.1,
+          font.lab  = 2,
+          cex.axis  = 1.0,
+          bty       = "l"
+        )
+
+        legend(
+          "topright",
+          legend = classes,
+          col    = cls_cols[seq_along(classes)],
+          pch    = 19,
+          pt.cex = 1.1,
+          bty    = "n",
+          cex    = 0.95,
+          title  = "Class"
+        )
       })
 
       showTab(inputId = "ldaMainPanel", target = "results_tab")

--- a/R/principalComponentAnalysis.R
+++ b/R/principalComponentAnalysis.R
@@ -509,13 +509,13 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
       req(pca_results())
       summary_df <- as.data.frame(summary(pca_results())$importance)[, 1:input$numFactors, drop = FALSE]
       round(summary_df, 3)
-    }, rownames = TRUE)
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
 
     output$pcaLoadings <- renderTable({
       req(pca_results())
       loadings_df <- as.data.frame(pca_results()$rotation)[, 1:input$numFactors, drop = FALSE]
       round(loadings_df, 3)
-    }, rownames = TRUE)
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
     
     output$pcaInterpretation <- renderUI({
       req(pca_results())
@@ -583,12 +583,12 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
     output$correlationMatrix <- renderTable({
       req(analysis_data())
       round(cor(analysis_data()), 4)
-    }, rownames = TRUE)
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
 
     output$covarianceMatrix <- renderTable({
       req(analysis_data())
       round(cov(analysis_data()), 4)
-    }, rownames = TRUE)
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
     
     output$screePlot <- renderPlot({
       req(pca_results())
@@ -637,7 +637,7 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
 
       rotated_loadings_df <- as.data.frame(unclass(rotated_pca$loadings))
       round(rotated_loadings_df, 3)
-    }, rownames = TRUE)
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
     
     observeEvent(input$reset, {
       hideTab(inputId = "mainPanel", target = "pca_results_tab")

--- a/R/randomForest.R
+++ b/R/randomForest.R
@@ -10,8 +10,8 @@ RFSidebarUI <- function(id) {
 
     sliderInput(
       ns("split"),
-      label = strong("Train/Test Split (%)"),
-      min = 50, max = 95, value = 80, step = 1
+      label = strong("Train/Test split (%)"),
+      min = 50, max = 90, value = 80, step = 1
     ),
 
     numericInput(
@@ -85,7 +85,9 @@ RFMainPanelUI <- function(id) {
         title = "Plots",
         value = "plots_tab",
         uiOutput(ns("rfVarImpContainer")),
-        uiOutput(ns("rfPDPContainer"))
+        uiOutput(ns("rfPDPContainer")),
+        uiOutput(ns("rfICEContainer")),
+        uiOutput(ns("rfALEContainer"))
       ),
 
       tabPanel(
@@ -452,8 +454,8 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
       # 17. Classification report (test set)
       rf_class_report <- knn_classification_report(test_df[[resp_col]], test_pred)$report
 
-      # 18. Partial dependence plots via iml (computed once, stored in res)
-      pdp_results <- tryCatch({
+      # 18. PDP and ICE via iml — predictor built once, both methods computed in one pass
+      iml_results <- tryCatch({
         predictor_iml <- suppressWarnings(
           iml::Predictor$new(
             model            = rf_fit,
@@ -462,6 +464,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
             predict.function = function(model, newdata) predict(model, newdata, type = "prob")
           )
         )
+
         pdp_list <- suppressWarnings(lapply(input$predictors, function(pvar) {
           tryCatch(
             iml::FeatureEffect$new(predictor_iml, feature = pvar, method = "pdp")$results,
@@ -469,8 +472,29 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
           )
         }))
         names(pdp_list) <- input$predictors
-        pdp_list
+
+        ice_list <- suppressWarnings(lapply(input$predictors, function(pvar) {
+          tryCatch(
+            iml::FeatureEffect$new(predictor_iml, feature = pvar, method = "ice")$results,
+            error = function(e) NULL
+          )
+        }))
+        names(ice_list) <- input$predictors
+
+        ale_list <- suppressWarnings(lapply(input$predictors, function(pvar) {
+          tryCatch(
+            iml::FeatureEffect$new(predictor_iml, feature = pvar, method = "ale")$results,
+            error = function(e) NULL
+          )
+        }))
+        names(ale_list) <- input$predictors
+
+        list(pdp = pdp_list, ice = ice_list, ale = ale_list)
       }, error = function(e) NULL)
+
+      pdp_results <- if (!is.null(iml_results)) iml_results$pdp else NULL
+      ice_results <- if (!is.null(iml_results)) iml_results$ice else NULL
+      ale_results <- if (!is.null(iml_results)) iml_results$ale else NULL
 
       res <- list(
         fit           = rf_fit,
@@ -489,7 +513,9 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         accuracy      = accuracy,
         class_metrics = class_metrics_df,
         class_report  = rf_class_report,
-        pdp_results   = pdp_results
+        pdp_results   = pdp_results,
+        ice_results   = ice_results,
+        ale_results   = ale_results
       )
 
       calc_results(res)
@@ -499,9 +525,11 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
 
-        oob_pct  <- round(r$oob_error * 100, 2)
-        acc_pct  <- round(r$accuracy  * 100, 2)
+        oob_pct        <- round(r$oob_error * 100, 2)
+        acc_pct        <- round(r$accuracy  * 100, 2)
         accuracy_label <- if (r$oob_error < 0.10) "high" else if (r$oob_error <= 0.25) "moderate" else "low"
+        rf_correct     <- sum(diag(r$confusion))
+        rf_total       <- sum(r$confusion)
 
         tagList(
           tags$h4("Model Summary"),
@@ -512,17 +540,21 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
           tags$hr(),
           tags$h4("Classification Report (Test Set)"),
           tableOutput(session$ns("rfClassReport")),
+          tags$script(HTML("setTimeout(function(){ if(typeof tippy!=='undefined') tippy('[data-tippy-content]'); }, 200);")),
           tags$hr(),
           tags$h4("Confusion Matrix (Test Set)"),
           tableOutput(session$ns("rfConfusionTable")),
+          tags$h5(tags$strong("Accuracy Calculation"),
+                  style = "margin-top: 14px; margin-bottom: 2px;"),
+          withMathJax(
+            tags$p(sprintf(
+              "\\[ \\text{Accuracy} = \\frac{\\text{Correct Predictions}}{\\text{Total Observations}} = \\frac{%d}{%d} = %.2f\\%% \\]",
+              rf_correct, rf_total, r$accuracy * 100
+            ))
+          ),
           tags$hr(),
           tags$h4("Per-Class Metrics"),
           tableOutput(session$ns("rfClassMetrics")),
-          tags$br(),
-          tags$p(
-            tags$strong("Overall Accuracy: "),
-            paste0(acc_pct, "%")
-          ),
           tags$hr(),
           tags$div(
             style = paste(
@@ -591,7 +623,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
 
         tagList(
           tags$table(
-            class = "table table-sm table-bordered",
+            class = "table table-sm table-bordered table-striped",
             style = "max-width: 480px;",
             tags$thead(
               tags$tr(
@@ -619,17 +651,39 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         r <- calc_results()
         req(r)
         r$class_report
-      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+         sanitize.colnames.function = function(x) {
+           tips <- c(
+             Precision = "Of all instances predicted as this class, the fraction that are truly this class. High precision means few false positives.",
+             Recall    = "Of all actual instances of this class, the fraction correctly predicted. High recall means few false negatives.",
+             F1        = "Harmonic mean of Precision and Recall — balances both into a single score.",
+             Support   = "Number of actual instances of this class in the dataset."
+           )
+           sapply(x, function(col) {
+             if (col %in% names(tips)) {
+               paste0('<b><span data-tippy-content="', tips[[col]],
+                      '" style="cursor:help;border-bottom:1px dotted #555;">', col, '</span></b>')
+             } else {
+               paste0("<b>", col, "</b>")
+             }
+           }, USE.NAMES = FALSE)
+         })
 
       output$rfConfusionTable <- renderTable({
         r <- calc_results()
         req(r)
         cm <- as.data.frame.matrix(r$confusion)
-        cm$Actual <- rownames(cm)
+        cm$Actual <- paste0("<b>", rownames(cm), "</b>")
         cm <- cm[, c("Actual", setdiff(names(cm), "Actual"))]
         rownames(cm) <- NULL
         cm
-      }, rownames = FALSE, striped = TRUE, bordered = TRUE)
+      }, rownames = FALSE, striped = TRUE, bordered = TRUE,
+         sanitize.text.function = identity,
+         sanitize.colnames.function = function(x) {
+           sapply(x, function(col) {
+             if (col == "Actual") "<b>Actual \\ Predicted</b>" else paste0("<b>", col, "</b>")
+           }, USE.NAMES = FALSE)
+         })
 
       output$rfClassMetrics <- renderTable({
         r <- calc_results()
@@ -640,7 +694,20 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
       output$rfVarImpContainer <- renderUI({
         tagList(
           tags$h4("Variable Importance Plots", style = "margin-top: 10px;"),
-          plotOutput(session$ns("rfVarImpPlot"), height = "550px")
+          plotOutput(session$ns("rfVarImpPlot"), height = "550px"),
+          tags$div(
+            style = "margin-top: 12px; font-size: 14px; color: #444;",
+            tags$p(
+              tags$strong("Mean Decrease in Accuracy: "),
+              "Measures how much the model's accuracy drops when the values of a variable are randomly shuffled. ",
+              "A large drop means the model relied heavily on that variable — it is highly important."
+            ),
+            tags$p(
+              tags$strong("Mean Decrease in Gini: "),
+              "Measures how much each variable contributes to reducing impurity (disorder) across all splits in all trees. ",
+              "A higher value means the variable is consistently useful for separating the classes."
+            )
+          )
         )
       })
 
@@ -757,11 +824,12 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
             main = pred_var,
             xlab = pred_var,
             ylab = "Predicted Probability",
-            cex.main = 1.1,
+            cex.main  = 1.3,
             font.main = 2,
-            cex.lab  = 0.95,
-            font.lab = 2,
-            cex.axis = 0.9
+            cex.lab   = 1.1,
+            font.lab  = 2,
+            cex.axis  = 1.0,
+            bty       = "l"
           )
 
           for (j in seq_along(cls_list)) {
@@ -782,6 +850,179 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         }
 
         # blank out remaining grid cells for odd predictor counts
+        remaining <- n_rows * n_cols - n_pred
+        for (k in seq_len(remaining)) plot.new()
+      })
+
+      output$rfICEContainer <- renderUI({
+        r <- calc_results()
+        req(r, !is.null(r$ice_results))
+
+        n_pred    <- length(r$predictors)
+        n_cols    <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
+        n_rows    <- ceiling(n_pred / n_cols)
+        height_px <- max(300, n_rows * 300)
+
+        tagList(
+          tags$hr(),
+          tags$h4("Individual Conditional Expectation Plots", style = "margin-top: 10px;"),
+          plotOutput(session$ns("rfICEPlot"), height = paste0(height_px, "px"))
+        )
+      })
+
+      output$rfICEPlot <- renderPlot({
+        r <- calc_results()
+        req(r, !is.null(r$ice_results))
+
+        n_pred  <- length(r$predictors)
+        n_cols  <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
+        n_rows  <- ceiling(n_pred / n_cols)
+
+        cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")
+
+        par(
+          mfrow = c(n_rows, n_cols),
+          oma   = c(0, 0, 0, 0),
+          mar   = c(4, 4, 5, 2)
+        )
+
+        for (pred_var in r$predictors) {
+          ice_df <- r$ice_results[[pred_var]]
+
+          if (is.null(ice_df)) {
+            plot.new()
+            title(main = pred_var, cex.main = 1.1, font.main = 2)
+            text(0.5, 0.5, "Could not compute ICE", cex = 0.9)
+            next
+          }
+
+          cls_list <- as.character(unique(ice_df$.class))
+
+          plot(
+            x    = NULL,
+            xlim = range(ice_df[[pred_var]], na.rm = TRUE),
+            ylim = c(0, 1),
+            main = pred_var,
+            xlab = pred_var,
+            ylab = "Predicted Probability",
+            cex.main  = 1.3,
+            font.main = 2,
+            cex.lab   = 1.1,
+            font.lab  = 2,
+            cex.axis  = 1.0,
+            bty       = "l"
+          )
+
+          for (j in seq_along(cls_list)) {
+            cls_ice <- ice_df[as.character(ice_df$.class) == cls_list[j], ]
+            x_vals  <- sort(unique(cls_ice[[pred_var]]))
+            obs_ids <- sort(unique(cls_ice$.id))
+
+            y_mat <- matrix(NA_real_, nrow = length(x_vals), ncol = length(obs_ids))
+            for (i in seq_along(obs_ids)) {
+              obs_df      <- cls_ice[cls_ice$.id == obs_ids[i], ]
+              obs_df      <- obs_df[order(obs_df[[pred_var]]), ]
+              y_mat[, i]  <- obs_df$.value
+            }
+
+            matlines(x_vals, y_mat,
+                     col = adjustcolor(cls_cols[j], alpha.f = 0.2),
+                     lty = 1, lwd = 0.7)
+          }
+
+          legend("topright", legend = cls_list,
+                 col = cls_cols[seq_along(cls_list)],
+                 lwd = 2, bty = "n", cex = 0.8)
+
+          mtext("Shows how the prediction changes for each individual observation as this variable changes.",
+                side = 3, line = 0.9, cex = 0.65, col = "#555555")
+          mtext("Each line represents one observation.",
+                side = 3, line = 0.2, cex = 0.65, col = "#555555")
+        }
+
+        remaining <- n_rows * n_cols - n_pred
+        for (k in seq_len(remaining)) plot.new()
+      })
+
+      output$rfALEContainer <- renderUI({
+        r <- calc_results()
+        req(r, !is.null(r$ale_results))
+
+        n_pred    <- length(r$predictors)
+        n_cols    <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
+        n_rows    <- ceiling(n_pred / n_cols)
+        height_px <- max(300, n_rows * 300)
+
+        tagList(
+          tags$hr(),
+          tags$h4("Accumulated Local Effects Plots", style = "margin-top: 10px;"),
+          plotOutput(session$ns("rfALEPlot"), height = paste0(height_px, "px"))
+        )
+      })
+
+      output$rfALEPlot <- renderPlot({
+        r <- calc_results()
+        req(r, !is.null(r$ale_results))
+
+        n_pred  <- length(r$predictors)
+        n_cols  <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
+        n_rows  <- ceiling(n_pred / n_cols)
+
+        cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")
+
+        par(
+          mfrow = c(n_rows, n_cols),
+          oma   = c(0, 0, 0, 0),
+          mar   = c(4, 4, 5, 2)
+        )
+
+        for (pred_var in r$predictors) {
+          ale_df <- r$ale_results[[pred_var]]
+
+          if (is.null(ale_df)) {
+            plot.new()
+            title(main = pred_var, cex.main = 1.1, font.main = 2)
+            text(0.5, 0.5, "Could not compute ALE", cex = 0.9)
+            next
+          }
+
+          cls_list <- as.character(unique(ale_df$.class))
+          y_range  <- range(ale_df$.value, na.rm = TRUE)
+
+          plot(
+            x    = NULL,
+            xlim = range(ale_df[[pred_var]], na.rm = TRUE),
+            ylim = y_range,
+            main = pred_var,
+            xlab = pred_var,
+            ylab = "ALE",
+            cex.main  = 1.3,
+            font.main = 2,
+            cex.lab   = 1.1,
+            font.lab  = 2,
+            cex.axis  = 1.0,
+            bty       = "l"
+          )
+
+          abline(h = 0, col = "grey70", lty = 2, lwd = 1)
+
+          for (j in seq_along(cls_list)) {
+            cls_df <- ale_df[as.character(ale_df$.class) == cls_list[j], ]
+            cls_df <- cls_df[order(cls_df[[pred_var]]), ]
+            lines(cls_df[[pred_var]], cls_df$.value,
+                  col = cls_cols[j], lwd = 2)
+          }
+
+          legend("topright", legend = cls_list,
+                 col = cls_cols[seq_along(cls_list)],
+                 lwd = 2, bty = "n", cex = 0.8)
+
+          mtext("Shows the accumulated local effect of this variable on the predicted outcome.",
+                side = 3, line = 0.9, cex = 0.65, col = "#555555")
+          mtext("More reliable than PDP when predictors are correlated.",
+                side = 3, line = 0.2, cex = 0.65, col = "#555555")
+        }
+
         remaining <- n_rows * n_cols - n_pred
         for (k in seq_len(remaining)) plot.new()
       })


### PR DESCRIPTION
- Added brief explanatory text below RF Variable Importance Plots describing Mean Decrease in Accuracy and Mean Decrease in Gini
- Decision boundary now only shows when checkbox is ticked and 2 variables are selected
- Replaced plain-text accuracy display in all four methods (KNN, LDA, CART, RF) fraction formula placed below the confusion matrix, RF Train/Test Split slider: max = 95 → max = 90.
- Confusion matrix top-left header: all four methods now show Actual \ Predicted
- KNN Plots tab overhaul (Removed Box Plots and Density Plots, Added Decision Boundary plot, A--- added Accuracy vs K plot which runs kNN for k=1 to max, highlights chosen k in orange)
- Addded Tippy tooltips on Classification Report headers (all four methods) + Standardise plot look across all methods -