### PR TITLE
ML tab changes

### DIFF
--- a/R/decisionTrees.R
+++ b/R/decisionTrees.R
@@ -655,7 +655,12 @@ CARTServer <- function(id, data, shared_explanatory, shared_response) {
           faclen = 0,
           varlen = 0,
           shadow.col = 0,
-          box.palette = "Blues"
+          box.palette = "Blues",
+          col        = "black",
+          split.col  = "black",
+          under.col  = "black",
+          branch.col = "black",
+          border.col = "black"
         )
       }, res = 96)
       

--- a/R/kNearestNeighbors.R
+++ b/R/kNearestNeighbors.R
@@ -911,7 +911,7 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
             mean(pred == s$y_test)
           })
 
-          par(mar = c(5, 4, 4, 2))
+          par(mar = c(7, 4, 4, 2))
 
           plot(
             k_vals, acc_vals,
@@ -938,7 +938,7 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
           }
 
           legend(
-            "right",
+            "bottom",
             legend = c("Accuracy", paste0("Selected k = ", s$k)),
             col    = c("#4472C4", "#ED7D31"),
             lty    = c(1, 2),
@@ -946,7 +946,10 @@ KNNServer <- function(id, data, shared_explanatory, shared_response) {
             pt.cex = c(0.6, 1.5),
             lwd    = c(2, 1.5),
             bty    = "n",
-            cex    = 0.95
+            cex    = 0.95,
+            horiz  = TRUE,
+            xpd    = TRUE,
+            inset  = c(0, -0.35)
           )
         })
 

--- a/R/linearDiscriminantAnalysis.R
+++ b/R/linearDiscriminantAnalysis.R
@@ -708,7 +708,7 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
         cls_cols <- c("#4472C4", "#ED7D31", "#70AD47", "#9E480E", "#7030A0")[seq_len(min(n_cls, 5))]
         col_vec  <- cls_cols[match(as.character(scores$Class), classes)]
 
-        par(mar = c(5, 4, 4, 2))
+        par(mar = c(9, 4, 4, 2))
 
         plot(
           scores$LD1,
@@ -727,15 +727,29 @@ LDAServer <- function(id, data, shared_explanatory, shared_response) {
           bty       = "l"
         )
 
+        # y is anchored via NDC (device-relative, resolution-independent) so the
+        # legend reliably lands just above the bottom edge regardless of the
+        # plot's rendered aspect ratio/resolution — a margin-relative inset was
+        # getting clipped off-device at some sizes. x is centered on the plot
+        # box (not the device) so it lines up with the "LD1" axis label, since
+        # unequal left/right margins shift the plot box off device-center.
+        legend_x <- mean(par("usr")[1:2])
+        legend_y <- grconvertY(0.02, from = "ndc", to = "user")
+
         legend(
-          "right",
+          x      = legend_x,
+          y      = legend_y,
+          xjust  = 0.5,
+          yjust  = 0,
           legend = classes,
           col    = cls_cols[seq_along(classes)],
           pch    = 19,
           pt.cex = 1.1,
           bty    = "n",
           cex    = 0.95,
-          title  = "Class"
+          title  = "Class",
+          horiz  = TRUE,
+          xpd    = NA
         )
       })
 

--- a/R/principalComponentAnalysis.R
+++ b/R/principalComponentAnalysis.R
@@ -84,25 +84,31 @@ PCAMainPanelUI <- function(id) {
              theme = bs_theme(version = 4),
                tabPanel(title = "Results",
                         value = "pca_results_tab",
-                        h3("Principal Component Analysis Summary"),
+                        h4("Principal Component Analysis Summary"),
                         tableOutput(ns("pcaSummary")),
                         hr(),
-                        h3("Component Loadings (Unrotated)"),
+                        h4("Component Loadings (Unrotated)"),
                         tableOutput(ns("pcaLoadings")),
                         hr(),
-                        h3("Component Loadings (Varimax Rotation)"),
+                        h4("Component Loadings (Varimax Rotation)"),
                         tableOutput(ns("rotatedLoadings")),
                         hr(),
-                        h3("Correlation Matrix"),
-                        tableOutput(ns("correlationMatrix")),
+                        h4("Correlation Matrix"),
+                        div(style = "display: flex; justify-content: center;",
+                            tableOutput(ns("correlationMatrix"))),
                         hr(),
-                        h3("Covariance Matrix"),
-                        tableOutput(ns("covarianceMatrix")),
-                        #hr(),
-                        #h3("Scree Plot"),
-                        #plotOutput(ns("screePlot")),
+                        h4("Covariance Matrix"),
+                        div(style = "display: flex; justify-content: center;",
+                            tableOutput(ns("covarianceMatrix"))),
                         hr(),
-                        h3("Interpretation of Results"),
+                        h4("Eigenvalues"),
+                        div(style = "display: flex; justify-content: center;",
+                            tableOutput(ns("eigenvaluesTable"))),
+                        hr(),
+                        h4("Eigenvectors"),
+                        div(style = "display: flex; justify-content: center;",
+                            tableOutput(ns("eigenvectorsTable"))),
+                        hr(),
                         uiOutput(ns("pcaInterpretation"))
                ),
                tabPanel(
@@ -459,14 +465,15 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
         ) +
         theme_minimal() +
         theme(
-          plot.title   = element_text(face = "bold", size = 14, hjust = 0.5),
-          axis.title.x = element_text(face = "bold", size = 14),
-          axis.title.y = element_text(face = "bold", size = 14),
-          axis.text.x  = element_text(face = "bold", size = 12),
-          axis.text.y  = element_text(face = "bold", size = 12)
+          plot.title      = element_text(face = "bold", size = 14, hjust = 0.5),
+          axis.title.x    = element_text(face = "bold", size = 14),
+          axis.title.y    = element_text(face = "bold", size = 14),
+          axis.text.x     = element_text(face = "bold", size = 12),
+          axis.text.y     = element_text(face = "bold", size = 12),
+          legend.position = "bottom"
         )
     }, res = 96)
-    
+
     output$loadingsHeatmap <- renderPlot({
       req(pca_results(), input$numFactors)
       
@@ -502,10 +509,11 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
         ) +
         theme_minimal() +
         theme(
-          plot.title   = element_text(face = "bold", size = 14, hjust = 0.5),
-          axis.title.x = element_text(face = "bold", size = 14),
-          axis.title.y = element_text(face = "bold", size = 14),
-          axis.text    = element_text(face = "bold", size = 12, colour = "black")
+          plot.title      = element_text(face = "bold", size = 14, hjust = 0.5),
+          axis.title.x    = element_text(face = "bold", size = 14),
+          axis.title.y    = element_text(face = "bold", size = 14),
+          axis.text       = element_text(face = "bold", size = 12, colour = "black"),
+          legend.position = "bottom"
         )
     }, res = 96)
     
@@ -524,43 +532,92 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
     
     output$pcaInterpretation <- renderUI({
       req(pca_results())
-      
-      summary_data <- summary(pca_results())$importance
+
+      summary_data  <- summary(pca_results())$importance
       loadings_data <- pca_results()$rotation
-      
-      # Interpretation of Summary
-      interpretation_summary <- tagList(
-        h4("Importance of Components"),
-        p(strong("Standard deviation:"), " This measures the amount of variance in the data explained by each principal component. Higher values mean more variance is captured."),
-        p(strong("Proportion of Variance:"), " This shows the percentage of the total variance that is accounted for by each principal component."),
-        p(strong("Cumulative Proportion:"), " This is the cumulative sum of the proportion of variance. It helps in deciding how many components to retain. A common rule of thumb is to select enough components to explain 70-80% of the total variance.")
-      )
-      
-      # Interpretation of Loadings
-      interpretation_loadings <- tagList(
-        h4("Component Loadings"),
-        p("Loadings are the correlations between the original variables and the principal components. They indicate how much each original variable contributes to each component.")
-      )
-      
-      loading_details <- lapply(1:input$numFactors, function(i) {
-        component_name <- colnames(loadings_data)[i]
+
+      cum_var_pct <- round(summary_data["Cumulative Proportion", input$numFactors] * 100, 2)
+      variance_label <- if (cum_var_pct >= 80) "excellent"
+                         else if (cum_var_pct >= 70) "good"
+                         else if (cum_var_pct >= 50) "moderate"
+                         else "limited"
+
+      # Per-component loading detail, characterizing each retained component
+      # by the variable that influences it most strongly.
+      loading_details <- lapply(seq_len(input$numFactors), function(i) {
+        component_name     <- colnames(loadings_data)[i]
         component_loadings <- loadings_data[, i]
-        
-        # Find the variable with the highest absolute loading
+
         top_variable_index <- which.max(abs(component_loadings))
-        top_variable_name <- rownames(loadings_data)[top_variable_index]
-        top_loading_value <- round(component_loadings[top_variable_index], 3)
-        
-        # Characterize the component
-        p(strong(component_name, ":"), 
-          " This component is most strongly influenced by ", 
-          strong(top_variable_name), 
-          " with a loading of ", 
-          strong(top_loading_value), 
-          ". Variables with high absolute loadings (close to 1 or -1) are important for interpreting this component.")
+        top_variable_name  <- rownames(loadings_data)[top_variable_index]
+        top_loading_value  <- round(component_loadings[top_variable_index], 3)
+
+        tags$p(
+          style = "margin-bottom: 6px;",
+          tags$strong(component_name, ": "),
+          "Most strongly influenced by ", tags$strong(top_variable_name),
+          " with a loading of ", tags$strong(top_loading_value),
+          ". Variables with high absolute loadings (close to 1 or -1) are important for ",
+          "interpreting this component."
+        )
       })
-      
-      tagList(interpretation_summary, interpretation_loadings, loading_details)
+
+      tags$div(
+        style = paste(
+          "background-color: #f8f9fa;",
+          "border-left: 4px solid #dee2e6;",
+          "border-radius: 4px;",
+          "padding: 16px 20px;",
+          "margin-top: 6px;"
+        ),
+        tags$h5(tags$strong("Interpretation of Results"),
+                style = "margin-top: 0; margin-bottom: 12px;"),
+
+        tags$p(
+          style = "margin-bottom: 8px;",
+          paste0(
+            "Principal Component Analysis reduces ", nrow(loadings_data), " variables down to ",
+            ncol(loadings_data), " uncorrelated components, ranked by how much variance each ",
+            "one captures."
+          )
+        ),
+
+        tags$p(tags$strong("Variance Explained"), style = "margin-bottom: 6px;"),
+        tags$p(
+          style = "margin-bottom: 4px;",
+          tags$strong("Standard deviation: "),
+          "The amount of variance in the data captured by each component. Higher values mean ",
+          "more variance is captured."
+        ),
+        tags$p(
+          style = "margin-bottom: 4px;",
+          tags$strong("Proportion of Variance: "),
+          "The percentage of total variance accounted for by each individual component."
+        ),
+        tags$p(
+          style = "margin-bottom: 8px;",
+          tags$strong("Cumulative Proportion: "),
+          "The running total of variance explained as components are added. A common rule of ",
+          "thumb is to retain enough components to explain 70-80% of total variance — the Scree ",
+          "Plot's \"elbow\" point is a visual way to confirm this cutoff."
+        ),
+        tags$p(
+          style = "margin-bottom: 12px;",
+          paste0(
+            "Your selected ", input$numFactors, " component", if (input$numFactors != 1) "s" else "",
+            " together explain ", cum_var_pct, "% of the total variance, which is ", variance_label,
+            " coverage."
+          )
+        ),
+
+        tags$p(tags$strong("Component Loadings"), style = "margin-bottom: 6px;"),
+        tags$p(
+          style = "margin-bottom: 8px;",
+          "Loadings are the correlations between the original variables and the principal ",
+          "components. They indicate how much each original variable contributes to each component."
+        ),
+        loading_details
+      )
     })
     
     output$transformationHistograms <- renderPlot({
@@ -588,13 +645,39 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
     output$correlationMatrix <- renderTable({
       req(analysis_data())
       round(cor(analysis_data()), 4)
-    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE, align = "c")
 
     output$covarianceMatrix <- renderTable({
       req(analysis_data())
       round(cov(analysis_data()), 4)
-    }, rownames = TRUE, striped = TRUE, bordered = TRUE)
-    
+    }, rownames = TRUE, striped = TRUE, bordered = TRUE, align = "c")
+
+    output$eigenvaluesTable <- renderTable({
+      req(pca_results())
+
+      eigenvalues <- pca_results()$sdev^2
+      prop_var    <- eigenvalues / sum(eigenvalues)
+      cum_var     <- cumsum(prop_var)
+
+      data.frame(
+        Component = paste0("PC", seq_along(eigenvalues)),
+        Eigenvalue = round(eigenvalues, 4),
+        `Proportion of Variance` = round(prop_var, 4),
+        `Cumulative Proportion` = round(cum_var, 4),
+        check.names = FALSE
+      )
+    }, rownames = FALSE, striped = TRUE, bordered = TRUE, align = "c")
+
+    output$eigenvectorsTable <- renderTable({
+      req(pca_results())
+
+      loadings <- pca_results()$rotation
+      df <- as.data.frame(round(loadings, 4))
+      df <- cbind(Variable = rownames(loadings), df)
+      rownames(df) <- NULL
+      df
+    }, rownames = FALSE, striped = TRUE, bordered = TRUE, align = "c")
+
     output$screePlot <- renderPlot({
       req(pca_results())
       
@@ -615,7 +698,11 @@ PCAServer <- function(id, data, shared_explanatory, shared_response) {
             plot.title   = element_text(face = "bold", size = 18, hjust = 0.5),
             axis.title.x = element_text(face = "bold", size = 14),
             axis.title.y = element_text(face = "bold", size = 14),
-            axis.text    = element_text(size = 12)
+            axis.text.x  = element_text(size = 12),
+            axis.text.y  = element_text(face = "bold", size = 12),
+            panel.border = element_blank(),
+            axis.line.x  = element_line(colour = "black", linewidth = 1),
+            axis.line.y  = element_line(colour = "black", linewidth = 1)
           )
       )
     }, res = 96)

--- a/R/randomForest.R
+++ b/R/randomForest.R
@@ -818,7 +818,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         n_pred    <- length(r$predictors)
         n_cols    <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
         n_rows    <- ceiling(n_pred / n_cols)
-        height_px <- max(300, n_rows * 300)
+        height_px <- max(380, n_rows * 380)
 
         tagList(
           tags$hr(),
@@ -840,7 +840,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         par(
           mfrow = c(n_rows, n_cols),
           oma   = c(0, 0, 0, 0),
-          mar   = c(4, 4, 5, 2)
+          mar   = c(8, 4, 5, 2)
         )
 
         for (pred_var in r$predictors) {
@@ -877,9 +877,11 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
                   col = cls_cols[j], lwd = 2)
           }
 
-          legend("right", legend = cls_list,
+          # Below the x-axis label, not just at the bottom of the plot area
+          legend("bottom", legend = cls_list,
                  col = cls_cols[seq_along(cls_list)],
-                 lwd = 2, bty = "n", cex = 0.8)
+                 lwd = 2, bty = "n", cex = 0.8, horiz = TRUE,
+                 xpd = TRUE, inset = c(0, -0.4))
 
           mtext("Shows the marginal effect of this variable on the predicted outcome,",
                 side = 3, line = 0.9, cex = 0.65, col = "#555555")
@@ -899,7 +901,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         n_pred    <- length(r$predictors)
         n_cols    <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
         n_rows    <- ceiling(n_pred / n_cols)
-        height_px <- max(300, n_rows * 300)
+        height_px <- max(380, n_rows * 380)
 
         tagList(
           tags$hr(),
@@ -921,7 +923,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         par(
           mfrow = c(n_rows, n_cols),
           oma   = c(0, 0, 0, 0),
-          mar   = c(4, 4, 5, 2)
+          mar   = c(8, 4, 5, 2)
         )
 
         for (pred_var in r$predictors) {
@@ -968,9 +970,10 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
                      lty = 1, lwd = 0.7)
           }
 
-          legend("right", legend = cls_list,
+          legend("bottom", legend = cls_list,
                  col = cls_cols[seq_along(cls_list)],
-                 lwd = 2, bty = "n", cex = 0.8)
+                 lwd = 2, bty = "n", cex = 0.8, horiz = TRUE,
+                 xpd = TRUE, inset = c(0, -0.4))
 
           mtext("Shows how the prediction changes for each individual observation as this variable changes.",
                 side = 3, line = 0.9, cex = 0.65, col = "#555555")
@@ -989,7 +992,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         n_pred    <- length(r$predictors)
         n_cols    <- if (n_pred <= 1) 1 else if (n_pred <= 4) 2 else 3
         n_rows    <- ceiling(n_pred / n_cols)
-        height_px <- max(300, n_rows * 300)
+        height_px <- max(380, n_rows * 380)
 
         tagList(
           tags$hr(),
@@ -1011,7 +1014,7 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
         par(
           mfrow = c(n_rows, n_cols),
           oma   = c(0, 0, 0, 0),
-          mar   = c(4, 4, 5, 2)
+          mar   = c(8, 4, 5, 2)
         )
 
         for (pred_var in r$predictors) {
@@ -1051,9 +1054,10 @@ RFServer <- function(id, data, shared_explanatory, shared_response) {
                   col = cls_cols[j], lwd = 2)
           }
 
-          legend("right", legend = cls_list,
+          legend("bottom", legend = cls_list,
                  col = cls_cols[seq_along(cls_list)],
-                 lwd = 2, bty = "n", cex = 0.8)
+                 lwd = 2, bty = "n", cex = 0.8, horiz = TRUE,
+                 xpd = TRUE, inset = c(0, -0.4))
 
           mtext("Shows the accumulated local effect of this variable on the predicted outcome.",
                 side = 3, line = 0.9, cex = 0.65, col = "#555555")

--- a/R/xgboost.R
+++ b/R/xgboost.R
@@ -17,7 +17,7 @@ XGBSidebarUI <- function(id) {
     numericInput(
       ns("nrounds"),
       strong("Number of Boosting Rounds (M)"),
-      value = 100, min = 1, step = 10
+      value = 100, min = 1, step = 1
     ),
 
     numericInput(
@@ -86,6 +86,7 @@ XGBMainPanelUI <- function(id) {
   tagList(
     useShinyjs(),
     suppressWarnings(tippy::use_tippy()),
+    withMathJax(),
     navbarPage(
       title = NULL,
 
@@ -135,6 +136,9 @@ XGBServer <- function(id, data, shared_explanatory, shared_response) {
     xgb_iv <- shinyvalidate::InputValidator$new()
     xgb_iv$add_rule("nrounds",   shinyvalidate::sv_required())
     xgb_iv$add_rule("nrounds",   shinyvalidate::sv_gte(1, message = "Must be at least 1."))
+    xgb_iv$add_rule("nrounds", function(v) {
+      if (!is.na(v) && v != round(v)) "Must be a whole number."
+    })
     xgb_iv$add_rule("max_depth", shinyvalidate::sv_required())
     xgb_iv$add_rule("max_depth", shinyvalidate::sv_gte(1, message = "Must be at least 1."))
     xgb_iv$add_rule("eta", shinyvalidate::sv_required())
@@ -613,6 +617,32 @@ XGBServer <- function(id, data, shared_explanatory, shared_response) {
                 round(r$subsample * 100), round(r$colsample_bytree * 100)
               ))
             ),
+            tags$div(
+              style = "margin: 4px 0 12px 0;",
+              tags$p(tags$strong("Additive Model Formula"), style = "margin-bottom: 6px;"),
+              tags$p(
+                style = "margin-bottom: 4px; text-align: center; font-size: 18px;",
+                HTML("$$ F_M(x) = F_0(x) + \\eta \\sum_{m=1}^{M} T_m(x) $$")
+              ),
+              tags$p(
+                style = "margin-bottom: 6px; text-align: center; font-size: 18px;",
+                HTML(sprintf(
+                  "$$ F_{%s}(x) = F_0(x) + %s \\sum_{m=1}^{%s} T_m(x) $$",
+                  r$nrounds, r$eta, r$nrounds
+                ))
+              ),
+              tags$p(
+                style = "margin-bottom: 0; color: #444;",
+                sprintf(
+                  paste0(
+                    "Starting from an initial prediction F₀(x), your model added %s trees ",
+                    "sequentially, each scaled by a learning rate of %s before being summed into ",
+                    "the final prediction."
+                  ),
+                  r$nrounds, r$eta
+                )
+              )
+            ),
             tags$p(
               style = "margin-bottom: 0;",
               paste0(
@@ -743,7 +773,7 @@ XGBServer <- function(id, data, shared_explanatory, shared_response) {
         iters     <- log_df$iter
         best_iter <- iters[which.min(test_err)]
 
-        par(mar = c(5, 4, 4, 2))
+        par(mar = c(7, 4, 4, 2))
 
         plot(
           iters, train_err,
@@ -765,13 +795,16 @@ XGBServer <- function(id, data, shared_explanatory, shared_response) {
         abline(v = best_iter, col = "#555555", lty = 2, lwd = 1.5)
 
         legend(
-          "topright",
+          "bottom",
           legend = c("Training Error", "Test Error", paste0("Best round = ", best_iter)),
           col    = c("#4472C4", "#ED7D31", "#555555"),
           lty    = c(1, 1, 2),
           lwd    = c(2, 2, 1.5),
           bty    = "n",
-          cex    = 0.95
+          cex    = 0.95,
+          horiz  = TRUE,
+          xpd    = TRUE,
+          inset  = c(0, -0.35)
         )
       })
 


### PR DESCRIPTION
  PCA
  - Hid "Data Transformation" section (sidebar + tab)
  - Restyled "Interpretation of Results" to match RF/XGB's
  - Scree plot: bold y-axis labels, outline on left/bottom
  - Centered Correlation & Covariance Matrix tables; added new centered Eigenvalues and Eigenvectors tables.
  - Biplot & loadings heatmap: legend moved to bottom.

  Gradient Boosting (XGBoost)
  - Added hyperparameter symbols (M, d, η, s, c) to sidebar labels.
  - nrounds (M) now integer-only step=1 + validation
 - Added additive-model formula (general + substituted with actual M/η) in display-style Latex
  - Training curve legend moved to bottom.

  Decision Trees: tree diagram text and connecting lines/borders forced to black
  (was poor-contrast with the previous yellow).

  Random Forest: PDP/ICE/ALE legends moved below the x-axis label with extra padding to
  avoid being covered by the next plot row.

  LDA scatter plot: legend moved to bottom, several rounds of fixing.